### PR TITLE
tak: final alignment and cloud event roundtrip coverage

### DIFF
--- a/src/main/java/io/mapsmessaging/network/protocol/impl/tak/TakExtension.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/tak/TakExtension.java
@@ -70,13 +70,20 @@ public class TakExtension extends Extension {
     this.url = new EndPointURL(endPoint.getConfig().getUrl());
     this.logger = LoggerFactory.getLogger(TakExtension.class);
     this.config = TakExtensionConfig.from(extensionConfig);
+    CotXmlCodec cotXmlCodec = CotXmlCodec.withSchemaFormatter(
+        config.isXmlNamespaceAware(),
+        config.isXmlCoalescing(),
+        config.isXmlValidating(),
+        config.getXmlRootEntry(),
+        config.getXmlSchemaId());
     this.payloadCodec = TakExtensionConfig.PAYLOAD_TAK_PROTO_V1.equalsIgnoreCase(config.getPayload())
         ? TakProtobufCodec.withSchemaFormatter(
-            new CotXmlCodec(),
+            cotXmlCodec,
             config.getMaxPayloadBytes(),
             config.getProtobufDescriptorBase64(),
-            config.getProtobufMessageName())
-        : new CotXmlCodec();
+            config.getProtobufMessageName(),
+            config.getProtobufSchemaId())
+        : cotXmlCodec;
     this.streamFramer = new TakStreamFramer(config.getFramingMode(), config.getMaxPayloadBytes());
     this.multicastTransport = config.isMulticastEnabled() ? new TakMulticastTransport(config) : null;
     this.frameReader = new TakFrameReader(streamFramer, config.getReadBufferBytes());
@@ -147,6 +154,7 @@ public class TakExtension extends Extension {
       if (multicastTransport != null && config.isMulticastEgressEnabled()) {
         try {
           multicastTransport.send(payload);
+          endPoint.updateWriteBytes(payload.length);
         } catch (IOException ignored) {
           logger.log(ServerLogMessages.TAK_MULTICAST_IO_FAILED, config.getMulticastGroup(), config.getMulticastPort());
         }
@@ -189,6 +197,7 @@ public class TakExtension extends Extension {
         if (frame.isEmpty()) {
           continue;
         }
+        endPoint.updateReadBytes(frame.get().length);
         processInboundFrame(frame.get(), "multicast");
       } catch (IOException ex) {
         if (!running.get()) {
@@ -203,6 +212,9 @@ public class TakExtension extends Extension {
     String eventType = null;
     if (message.getMeta() != null) {
       eventType = message.getMeta().get("tak.type");
+      if (eventType == null || eventType.isBlank()) {
+        eventType = message.getMeta().get("tak_type");
+      }
     }
     if (eventType == null || eventType.isBlank()) {
       eventType = DEFAULT_EVENT_TYPE;

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/tak/TakExtensionConfig.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/tak/TakExtensionConfig.java
@@ -42,6 +42,12 @@ public class TakExtensionConfig {
   private static final int DEFAULT_MULTICAST_TTL = 1;
   private static final String DEFAULT_PROTOBUF_DESCRIPTOR_BASE64 = "";
   private static final String DEFAULT_PROTOBUF_MESSAGE_NAME = "";
+  private static final String DEFAULT_XML_SCHEMA_ID = "";
+  private static final String DEFAULT_PROTOBUF_SCHEMA_ID = "";
+  private static final boolean DEFAULT_XML_NAMESPACE_AWARE = true;
+  private static final boolean DEFAULT_XML_COALESCING = true;
+  private static final boolean DEFAULT_XML_VALIDATING = false;
+  private static final String DEFAULT_XML_ROOT_ENTRY = "event";
 
   private final String payload;
   private final TakStreamFramer.Mode framingMode;
@@ -61,12 +67,20 @@ public class TakExtensionConfig {
   private final int multicastReadBufferBytes;
   private final String protobufDescriptorBase64;
   private final String protobufMessageName;
+  private final String xmlSchemaId;
+  private final String protobufSchemaId;
+  private final boolean xmlNamespaceAware;
+  private final boolean xmlCoalescing;
+  private final boolean xmlValidating;
+  private final String xmlRootEntry;
 
   private TakExtensionConfig(String payload, TakStreamFramer.Mode framingMode, int maxPayloadBytes, int reconnectDelayMs,
                              int reconnectMaxDelayMs, double reconnectBackoffMultiplier, int reconnectJitterMs, int readBufferBytes,
                              boolean multicastEnabled, boolean multicastIngressEnabled, boolean multicastEgressEnabled,
                              String multicastGroup, int multicastPort, String multicastInterface, int multicastTtl, int multicastReadBufferBytes,
-                             String protobufDescriptorBase64, String protobufMessageName) {
+                             String protobufDescriptorBase64, String protobufMessageName,
+                             String xmlSchemaId, String protobufSchemaId,
+                             boolean xmlNamespaceAware, boolean xmlCoalescing, boolean xmlValidating, String xmlRootEntry) {
     this.payload = payload;
     this.framingMode = framingMode;
     this.maxPayloadBytes = maxPayloadBytes;
@@ -85,6 +99,12 @@ public class TakExtensionConfig {
     this.multicastReadBufferBytes = multicastReadBufferBytes;
     this.protobufDescriptorBase64 = protobufDescriptorBase64;
     this.protobufMessageName = protobufMessageName;
+    this.xmlSchemaId = xmlSchemaId;
+    this.protobufSchemaId = protobufSchemaId;
+    this.xmlNamespaceAware = xmlNamespaceAware;
+    this.xmlCoalescing = xmlCoalescing;
+    this.xmlValidating = xmlValidating;
+    this.xmlRootEntry = xmlRootEntry;
   }
 
   public static TakExtensionConfig from(ExtensionConfigDTO extensionConfig) {
@@ -108,6 +128,12 @@ public class TakExtensionConfig {
     int multicastReadBuffer = asInt(config, "multicast_read_buffer_bytes", DEFAULT_READ_BUFFER);
     String protobufDescriptorBase64 = asString(config, "protobuf_descriptor_base64", DEFAULT_PROTOBUF_DESCRIPTOR_BASE64).trim();
     String protobufMessageName = asString(config, "protobuf_message_name", DEFAULT_PROTOBUF_MESSAGE_NAME).trim();
+    String xmlSchemaId = asString(config, "xml_schema_id", DEFAULT_XML_SCHEMA_ID).trim();
+    String protobufSchemaId = asString(config, "protobuf_schema_id", DEFAULT_PROTOBUF_SCHEMA_ID).trim();
+    boolean xmlNamespaceAware = asBoolean(config, "xml_namespace_aware", DEFAULT_XML_NAMESPACE_AWARE);
+    boolean xmlCoalescing = asBoolean(config, "xml_coalescing", DEFAULT_XML_COALESCING);
+    boolean xmlValidating = asBoolean(config, "xml_validating", DEFAULT_XML_VALIDATING);
+    String xmlRootEntry = asString(config, "xml_root_entry", DEFAULT_XML_ROOT_ENTRY).trim();
     int reconnectBase = Math.max(100, reconnectMs);
     int reconnectMax = Math.max(reconnectBase, reconnectMaxMs);
     return new TakExtensionConfig(payload, mode, Math.max(1024, maxPayload), reconnectBase,
@@ -119,7 +145,13 @@ public class TakExtensionConfig {
         Math.max(1, Math.min(255, multicastTtl)),
         Math.max(512, multicastReadBuffer),
         protobufDescriptorBase64,
-        protobufMessageName);
+        protobufMessageName,
+        xmlSchemaId,
+        protobufSchemaId,
+        xmlNamespaceAware,
+        xmlCoalescing,
+        xmlValidating,
+        xmlRootEntry.isEmpty() ? DEFAULT_XML_ROOT_ENTRY : xmlRootEntry);
   }
 
   private static String asString(Map<String, Object> config, String key, String def) {

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/tak/TakProtocolFactory.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/tak/TakProtocolFactory.java
@@ -26,6 +26,7 @@ import io.mapsmessaging.network.io.Packet;
 import io.mapsmessaging.network.protocol.Protocol;
 import io.mapsmessaging.network.protocol.ProtocolImplFactory;
 import io.mapsmessaging.network.protocol.detection.NoOpDetection;
+import io.mapsmessaging.network.protocol.impl.extension.ExtensionEndPoint;
 import io.mapsmessaging.network.protocol.impl.extension.ExtensionProtocol;
 
 import java.io.IOException;
@@ -38,17 +39,22 @@ public class TakProtocolFactory extends ProtocolImplFactory {
 
   @Override
   public Protocol connect(EndPoint endPoint, String sessionId, String username, String password) throws IOException {
-    ExtensionConfigDTO extensionConfig = null;
-    if (endPoint.getConfig() != null && endPoint.getConfig().getProtocolConfigs() != null) {
-      for (ProtocolConfigDTO protocolConfig : endPoint.getConfig().getProtocolConfigs()) {
-        if (protocolConfig instanceof ExtensionConfigDTO config && getName().equalsIgnoreCase(config.getProtocol())) {
-          extensionConfig = config;
-          break;
+    ExtensionConfigDTO extensionConfig;
+    if (endPoint instanceof ExtensionEndPoint extensionEndPoint && extensionEndPoint.config() instanceof ExtensionConfigDTO config) {
+      extensionConfig = config;
+    } else {
+      extensionConfig = null;
+      if (endPoint.getConfig() != null && endPoint.getConfig().getProtocolConfigs() != null) {
+        for (ProtocolConfigDTO protocolConfig : endPoint.getConfig().getProtocolConfigs()) {
+          if (protocolConfig instanceof ExtensionConfigDTO config && getName().equalsIgnoreCase(config.getProtocol())) {
+            extensionConfig = config;
+            break;
+          }
         }
       }
-    }
-    if (extensionConfig == null) {
-      throw new IOException("TAK extension configuration not found");
+      if (extensionConfig == null) {
+        throw new IOException("TAK extension configuration not found");
+      }
     }
 
     Protocol protocol = new ExtensionProtocol(endPoint, new TakExtension(endPoint, extensionConfig));

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/tak/codec/CotXmlCodec.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/tak/codec/CotXmlCodec.java
@@ -19,9 +19,16 @@
 
 package io.mapsmessaging.network.protocol.impl.tak.codec;
 
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.WireFormat;
 import io.mapsmessaging.api.MessageBuilder;
 import io.mapsmessaging.api.features.QualityOfService;
 import io.mapsmessaging.api.message.Message;
+import io.mapsmessaging.engine.schema.SchemaManager;
+import io.mapsmessaging.schemas.config.impl.XmlSchemaConfig;
+import io.mapsmessaging.schemas.formatters.MessageFormatter;
+import io.mapsmessaging.schemas.formatters.MessageFormatterFactory;
+import io.mapsmessaging.selector.IdentifierResolver;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -41,6 +48,30 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CotXmlCodec implements TakPayloadCodec {
+
+  private final MessageFormatter xmlFormatter;
+  private final String schemaId;
+
+  public CotXmlCodec() {
+    this(null, SchemaManager.DEFAULT_XML_SCHEMA.toString());
+  }
+
+  public CotXmlCodec(MessageFormatter xmlFormatter) {
+    this(xmlFormatter, SchemaManager.DEFAULT_XML_SCHEMA.toString());
+  }
+
+  public CotXmlCodec(MessageFormatter xmlFormatter, String schemaId) {
+    this.xmlFormatter = xmlFormatter;
+    this.schemaId = schemaId;
+  }
+
+  public static CotXmlCodec withSchemaFormatter(boolean namespaceAware, boolean coalescing, boolean validating, String rootEntry) {
+    return withSchemaFormatter(namespaceAware, coalescing, validating, rootEntry, SchemaManager.DEFAULT_XML_SCHEMA.toString());
+  }
+
+  public static CotXmlCodec withSchemaFormatter(boolean namespaceAware, boolean coalescing, boolean validating, String rootEntry, String schemaId) {
+    return new CotXmlCodec(createFormatter(namespaceAware, coalescing, validating, rootEntry), schemaId);
+  }
 
   @Override
   public Message decode(byte[] payload) throws IOException {
@@ -71,22 +102,35 @@ public class CotXmlCodec implements TakPayloadCodec {
     putIfPresent(meta, "tak.le", point.getAttribute("le"));
     meta.put("tak.format", "xml");
     meta.put("tak.transport", "stream");
+    mergeSchemaParsedMeta(meta, payload);
+    addSelectorAliases(meta);
 
-    return new MessageBuilder()
+    MessageBuilder builder = new MessageBuilder()
         .setOpaqueData(payload)
         .setMeta(meta)
         .setContentType("application/cot+xml")
-        .setQoS(QualityOfService.AT_MOST_ONCE)
-        .build();
+        .setQoS(QualityOfService.AT_MOST_ONCE);
+    if (schemaId != null && !schemaId.isBlank()) {
+      builder.setSchemaId(schemaId);
+    }
+    return builder.build();
   }
 
   @Override
   public byte[] encode(Message message) throws IOException {
     byte[] opaque = message.getOpaqueData();
+    byte[] cloudEventPayload = TakCloudEventPayloadExtractor.tryExtractPayload(opaque);
+    if (cloudEventPayload != null) {
+      opaque = cloudEventPayload;
+    }
     if (opaque != null && opaque.length > 0) {
       String candidate = new String(opaque, StandardCharsets.UTF_8).trim();
       if (candidate.startsWith("<event")) {
         return opaque;
+      }
+      byte[] embeddedCot = tryExtractEmbeddedCotFromProtobuf(opaque);
+      if (embeddedCot != null) {
+        return embeddedCot;
       }
     }
     Map<String, String> meta = message.getMeta() != null ? message.getMeta() : new LinkedHashMap<>();
@@ -110,6 +154,33 @@ public class CotXmlCodec implements TakPayloadCodec {
         + "<point lat=\"" + esc(lat) + "\" lon=\"" + esc(lon) + "\" hae=\"" + esc(hae) + "\" ce=\"" + esc(ce) + "\" le=\"" + esc(le) + "\"/>"
         + "</event>";
     return xml.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static byte[] tryExtractEmbeddedCotFromProtobuf(byte[] payload) {
+    try {
+      CodedInputStream input = CodedInputStream.newInstance(payload);
+      while (!input.isAtEnd()) {
+        int tag = input.readTag();
+        if (tag == 0) {
+          break;
+        }
+        int wireType = WireFormat.getTagWireType(tag);
+        if (wireType == WireFormat.WIRETYPE_LENGTH_DELIMITED) {
+          byte[] candidate = input.readByteArray();
+          if (candidate.length > 0) {
+            String xmlCandidate = new String(candidate, StandardCharsets.UTF_8).trim();
+            if (xmlCandidate.startsWith("<event")) {
+              return candidate;
+            }
+          }
+        } else if (!input.skipField(tag)) {
+          break;
+        }
+      }
+    } catch (Exception ignored) {
+      // non-protobuf payload; fall through to metadata-based reconstruction
+    }
+    return null;
   }
 
   private static String getOrDefault(Map<String, String> meta, String key, String def) {
@@ -173,5 +244,79 @@ public class CotXmlCodec implements TakPayloadCodec {
         .replace("\"", "&quot;")
         .replace("<", "&lt;")
         .replace(">", "&gt;");
+  }
+
+  private void mergeSchemaParsedMeta(Map<String, String> meta, byte[] payload) {
+    if (xmlFormatter == null) {
+      return;
+    }
+    try {
+      IdentifierResolver parsed = xmlFormatter.parse(payload);
+      if (parsed == null) {
+        return;
+      }
+      promoteAny(parsed, meta, "tak.uid", "uid", "event.uid");
+      promoteAny(parsed, meta, "tak.type", "type", "event.type");
+      promoteAny(parsed, meta, "tak.time", "time", "event.time");
+      promoteAny(parsed, meta, "tak.start", "start", "event.start");
+      promoteAny(parsed, meta, "tak.stale", "stale", "event.stale");
+      promoteAny(parsed, meta, "tak.how", "how", "event.how");
+      promoteAny(parsed, meta, "tak.lat", "point.lat", "event.point.lat");
+      promoteAny(parsed, meta, "tak.lon", "point.lon", "event.point.lon");
+      promoteAny(parsed, meta, "tak.hae", "point.hae", "event.point.hae");
+      promoteAny(parsed, meta, "tak.ce", "point.ce", "event.point.ce");
+      promoteAny(parsed, meta, "tak.le", "point.le", "event.point.le");
+      meta.put("tak.xml_schema_parsed", "true");
+    } catch (Exception ignored) {
+      // Preserve default CoT metadata extraction if formatter parsing fails.
+    }
+  }
+
+  private static void promoteAny(IdentifierResolver parsed, Map<String, String> meta, String toKey, String... fromKeys) {
+    for (String fromKey : fromKeys) {
+      Object val = parsed.get(fromKey);
+      if (val != null) {
+        meta.put(toKey, val.toString());
+        return;
+      }
+    }
+  }
+
+  private static void addSelectorAliases(Map<String, String> meta) {
+    alias(meta, "tak.uid", "tak_uid");
+    alias(meta, "tak.type", "tak_type");
+    alias(meta, "tak.time", "tak_time");
+    alias(meta, "tak.start", "tak_start");
+    alias(meta, "tak.stale", "tak_stale");
+    alias(meta, "tak.how", "tak_how");
+    alias(meta, "tak.lat", "tak_lat");
+    alias(meta, "tak.lon", "tak_lon");
+    alias(meta, "tak.hae", "tak_hae");
+    alias(meta, "tak.ce", "tak_ce");
+    alias(meta, "tak.le", "tak_le");
+    alias(meta, "tak.format", "tak_format");
+    alias(meta, "tak.transport", "tak_transport");
+  }
+
+  private static void alias(Map<String, String> meta, String sourceKey, String aliasKey) {
+    String value = meta.get(sourceKey);
+    if (value != null && !value.isBlank()) {
+      meta.put(aliasKey, value);
+    }
+  }
+
+  private static MessageFormatter createFormatter(boolean namespaceAware, boolean coalescing, boolean validating, String rootEntry) {
+    try {
+      XmlSchemaConfig schemaConfig = new XmlSchemaConfig();
+      XmlSchemaConfig.XmlConfig xmlConfig = new XmlSchemaConfig.XmlConfig();
+      xmlConfig.setNamespaceAware(namespaceAware);
+      xmlConfig.setCoalescing(coalescing);
+      xmlConfig.setValidating(validating);
+      xmlConfig.setRootEntry(rootEntry == null || rootEntry.isBlank() ? "event" : rootEntry);
+      schemaConfig.setConfig(xmlConfig);
+      return MessageFormatterFactory.getInstance().getFormatter(schemaConfig);
+    } catch (Exception ignored) {
+      return null;
+    }
   }
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/tak/codec/TakCloudEventPayloadExtractor.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/tak/codec/TakCloudEventPayloadExtractor.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.network.protocol.impl.tak.codec;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+final class TakCloudEventPayloadExtractor {
+
+  private TakCloudEventPayloadExtractor() {
+  }
+
+  static byte[] tryExtractPayload(byte[] opaqueData) {
+    if (opaqueData == null || opaqueData.length == 0) {
+      return null;
+    }
+    String jsonCandidate = new String(opaqueData, StandardCharsets.UTF_8).trim();
+    if (!jsonCandidate.startsWith("{")) {
+      return null;
+    }
+    try {
+      JsonElement rootElement = JsonParser.parseString(jsonCandidate);
+      if (!rootElement.isJsonObject()) {
+        return null;
+      }
+      JsonObject root = rootElement.getAsJsonObject();
+      if (!root.has("specversion")) {
+        return null;
+      }
+
+      JsonElement base64Element = root.get("data_base64");
+      if (base64Element != null && base64Element.isJsonPrimitive()) {
+        return Base64.getDecoder().decode(base64Element.getAsString());
+      }
+
+      JsonElement dataElement = root.get("data");
+      if (dataElement == null || !dataElement.isJsonObject()) {
+        return null;
+      }
+      JsonObject data = dataElement.getAsJsonObject();
+      JsonElement payloadBase64 = data.get("payload_base64");
+      if (payloadBase64 != null && payloadBase64.isJsonPrimitive()) {
+        return Base64.getDecoder().decode(payloadBase64.getAsString());
+      }
+      return null;
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+}
+

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/tak/codec/TakProtobufCodec.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/tak/codec/TakProtobufCodec.java
@@ -42,24 +42,35 @@ public class TakProtobufCodec implements TakPayloadCodec {
   private final CotXmlCodec cotXmlCodec;
   private final int maxPayloadBytes;
   private final MessageFormatter protobufFormatter;
+  private final String protobufSchemaId;
 
   public TakProtobufCodec() {
-    this(new CotXmlCodec(), DEFAULT_MAX_PAYLOAD_BYTES, null);
+    this(new CotXmlCodec(), DEFAULT_MAX_PAYLOAD_BYTES, null, null);
   }
 
   public TakProtobufCodec(CotXmlCodec cotXmlCodec, int maxPayloadBytes) {
-    this(cotXmlCodec, maxPayloadBytes, null);
+    this(cotXmlCodec, maxPayloadBytes, null, null);
   }
 
   public TakProtobufCodec(CotXmlCodec cotXmlCodec, int maxPayloadBytes, MessageFormatter protobufFormatter) {
+    this(cotXmlCodec, maxPayloadBytes, protobufFormatter, null);
+  }
+
+  public TakProtobufCodec(CotXmlCodec cotXmlCodec, int maxPayloadBytes, MessageFormatter protobufFormatter, String protobufSchemaId) {
     this.cotXmlCodec = cotXmlCodec;
     this.maxPayloadBytes = Math.max(1024, maxPayloadBytes);
     this.protobufFormatter = protobufFormatter;
+    this.protobufSchemaId = protobufSchemaId;
   }
 
   public static TakProtobufCodec withSchemaFormatter(CotXmlCodec cotXmlCodec, int maxPayloadBytes,
                                                      String descriptorBase64, String messageName) {
-    return new TakProtobufCodec(cotXmlCodec, maxPayloadBytes, createFormatter(descriptorBase64, messageName));
+    return withSchemaFormatter(cotXmlCodec, maxPayloadBytes, descriptorBase64, messageName, null);
+  }
+
+  public static TakProtobufCodec withSchemaFormatter(CotXmlCodec cotXmlCodec, int maxPayloadBytes,
+                                                     String descriptorBase64, String messageName, String protobufSchemaId) {
+    return new TakProtobufCodec(cotXmlCodec, maxPayloadBytes, createFormatter(descriptorBase64, messageName), protobufSchemaId);
   }
 
   @Override
@@ -76,11 +87,15 @@ public class TakProtobufCodec implements TakPayloadCodec {
     meta.put("tak.transport", "stream");
 
     byte[] embeddedCot = extractEmbeddedCotXml(payload);
+    String schemaId = protobufSchemaId;
     if (embeddedCot != null) {
       try {
         Message cotMessage = cotXmlCodec.decode(embeddedCot);
         if (cotMessage.getMeta() != null) {
           meta.putAll(cotMessage.getMeta());
+        }
+        if (cotMessage.getSchemaId() != null && !cotMessage.getSchemaId().isBlank()) {
+          schemaId = cotMessage.getSchemaId();
         }
         meta.put("tak.format", "protobuf");
         meta.put("tak.transport", "stream");
@@ -91,17 +106,25 @@ public class TakProtobufCodec implements TakPayloadCodec {
     } else if (protobufFormatter != null) {
       mergeSchemaParsedMeta(meta, payload);
     }
+    addSelectorAliases(meta);
 
-    return new MessageBuilder()
+    MessageBuilder builder = new MessageBuilder()
         .setOpaqueData(payload)
         .setContentType("application/x-protobuf")
-        .setMeta(meta)
-        .build();
+        .setMeta(meta);
+    if (schemaId != null && !schemaId.isBlank()) {
+      builder.setSchemaId(schemaId);
+    }
+    return builder.build();
   }
 
   @Override
   public byte[] encode(Message message) throws IOException {
     byte[] opaque = message.getOpaqueData();
+    byte[] cloudEventPayload = TakCloudEventPayloadExtractor.tryExtractPayload(opaque);
+    if (cloudEventPayload != null) {
+      opaque = cloudEventPayload;
+    }
     if (opaque != null && opaque.length > 0 && !looksLikeCotXml(opaque)) {
       if (opaque.length > maxPayloadBytes) {
         throw new IOException("TAK protobuf payload exceeds max size");
@@ -158,22 +181,48 @@ public class TakProtobufCodec implements TakPayloadCodec {
       if (parsed == null) {
         return;
       }
-      promote(parsed, meta, "uid", "tak.uid");
-      promote(parsed, meta, "type", "tak.type");
-      promote(parsed, meta, "time", "tak.time");
-      promote(parsed, meta, "start", "tak.start");
-      promote(parsed, meta, "stale", "tak.stale");
-      promote(parsed, meta, "how", "tak.how");
+      promoteAny(parsed, meta, "tak.uid", "uid", "event.uid");
+      promoteAny(parsed, meta, "tak.type", "type", "event.type");
+      promoteAny(parsed, meta, "tak.time", "time", "event.time");
+      promoteAny(parsed, meta, "tak.start", "start", "event.start");
+      promoteAny(parsed, meta, "tak.stale", "stale", "event.stale");
+      promoteAny(parsed, meta, "tak.how", "how", "event.how");
       meta.put("tak.protobuf_parsed", "true");
     } catch (Exception ignored) {
       // keep base protobuf metadata when schema parsing fails
     }
   }
 
-  private static void promote(IdentifierResolver parsed, Map<String, String> meta, String fromKey, String toKey) {
-    Object val = parsed.get(fromKey);
-    if (val != null) {
-      meta.put(toKey, val.toString());
+  private static void promoteAny(IdentifierResolver parsed, Map<String, String> meta, String toKey, String... fromKeys) {
+    for (String fromKey : fromKeys) {
+      Object val = parsed.get(fromKey);
+      if (val != null) {
+        meta.put(toKey, val.toString());
+        return;
+      }
+    }
+  }
+
+  private static void addSelectorAliases(Map<String, String> meta) {
+    alias(meta, "tak.uid", "tak_uid");
+    alias(meta, "tak.type", "tak_type");
+    alias(meta, "tak.time", "tak_time");
+    alias(meta, "tak.start", "tak_start");
+    alias(meta, "tak.stale", "tak_stale");
+    alias(meta, "tak.how", "tak_how");
+    alias(meta, "tak.lat", "tak_lat");
+    alias(meta, "tak.lon", "tak_lon");
+    alias(meta, "tak.hae", "tak_hae");
+    alias(meta, "tak.ce", "tak_ce");
+    alias(meta, "tak.le", "tak_le");
+    alias(meta, "tak.format", "tak_format");
+    alias(meta, "tak.transport", "tak_transport");
+  }
+
+  private static void alias(Map<String, String> meta, String sourceKey, String aliasKey) {
+    String value = meta.get(sourceKey);
+    if (value != null && !value.isBlank()) {
+      meta.put(aliasKey, value);
     }
   }
 

--- a/src/main/resources/NetworkConnectionManager.yaml
+++ b/src/main/resources/NetworkConnectionManager.yaml
@@ -79,6 +79,18 @@ NetworkConnectionManager:
       #     framing: xml_stream
       #     max_payload_bytes: 1048576
       #     reconnect_delay_ms: 2000
+      #     reconnect_max_delay_ms: 30000
+      #     reconnect_backoff_multiplier: 2.0
+      #     reconnect_jitter_ms: 250
+      #     read_buffer_bytes: 8192
+      #     xml_schema_id: "10000000-0000-1000-a000-100000000004" # default XML schema
+      #
+      #     # Optional protobuf mode:
+      #     # payload: tak_proto_v1
+      #     # framing: proto_stream
+      #     # protobuf_descriptor_base64: "<base64 file descriptor set>"
+      #     # protobuf_message_name: "TakMessage"
+      #     # protobuf_schema_id: "<registered protobuf schema uuid>"
       #
       #   links:
       #     - direction: pull
@@ -90,5 +102,5 @@ NetworkConnectionManager:
       #     - direction: push
       #       remote_namespace: "tak/cot/out/#"
       #       local_namespace: "ops/cot/out/"
-      #       selector: "tak.type LIKE 'a-%'"
+      #       selector: "tak_type LIKE 'a-%'"
       #       qos: 0

--- a/src/test/java/io/mapsmessaging/api/transformers/TakToCloudEventTransformationTest.java
+++ b/src/test/java/io/mapsmessaging/api/transformers/TakToCloudEventTransformationTest.java
@@ -1,0 +1,183 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.api.transformers;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.mapsmessaging.api.message.Message;
+import io.mapsmessaging.engine.schema.SchemaManager;
+import io.mapsmessaging.network.protocol.impl.tak.codec.CotXmlCodec;
+import io.mapsmessaging.network.protocol.impl.tak.codec.TakProtobufCodec;
+import io.mapsmessaging.network.protocol.transformation.cloudevent.CloudEventEnvelopeTransformation;
+import io.mapsmessaging.network.protocol.transformation.cloudevent.CloudEventJsonTransformation;
+import io.mapsmessaging.network.protocol.transformation.cloudevent.CloudEventNativeTransformation;
+import io.mapsmessaging.schemas.config.impl.ProtoBufSchemaConfig;
+import io.mapsmessaging.test.BaseTestConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TakToCloudEventTransformationTest extends BaseTestConfig {
+
+  private final SchemaManager schemaManager = SchemaManager.getInstance();
+  private UUID protobufSchemaId;
+
+  @AfterEach
+  void cleanUpSchema() {
+    if (protobufSchemaId != null) {
+      schemaManager.removeSchema(protobufSchemaId.toString());
+      protobufSchemaId = null;
+    }
+  }
+
+  @Test
+  void cotXmlDecodedMessageTransformsToCloudEventJsonData() throws Exception {
+    CotXmlCodec codec = new CotXmlCodec();
+    byte[] cotPayload = """
+        <event uid="u-xml-1" type="a-f-G-U-C" time="2026-02-19T09:10:00Z" start="2026-02-19T09:10:00Z" stale="2026-02-19T09:15:00Z" how="m-g">
+          <point lat="51.5007" lon="-0.1246" hae="35.0" ce="10.0" le="15.0"/>
+        </event>
+        """.getBytes(StandardCharsets.UTF_8);
+    Message takMessage = codec.decode(cotPayload);
+
+    Message cloudEventMessage = new CloudEventJsonTransformation().outgoing(takMessage, "/tak/cot/in");
+    assertNotNull(cloudEventMessage);
+    JsonObject cloudEvent = JsonParser.parseString(new String(cloudEventMessage.getOpaqueData(), StandardCharsets.UTF_8)).getAsJsonObject();
+
+    assertEquals("1.0", cloudEvent.get("specversion").getAsString());
+    assertEquals("application/json", cloudEvent.get("datacontenttype").getAsString());
+    assertTrue(cloudEvent.has("data"));
+    assertFalse(cloudEvent.getAsJsonObject("data").has("payload_base64"));
+    assertEquals("u-xml-1", cloudEvent.get("mapsMeta_tak_uid").getAsString());
+    assertEquals("xml", cloudEvent.get("mapsMeta_tak_format").getAsString());
+  }
+
+  @Test
+  void takProtobufDecodedMessageTransformsToCloudEventJsonData() throws Exception {
+    protobufSchemaId = UUID.randomUUID();
+    ProtoBufSchemaConfig schema = (ProtoBufSchemaConfig) TestProtobufSchemas.protobufSchemaConfig(protobufSchemaId);
+    schemaManager.addSchema("/tak/proto", schema);
+    String descriptorBase64 = Base64.getEncoder().encodeToString(schema.getProtobufConfig().getDescriptorValue());
+    String messageName = schema.getProtobufConfig().getMessageName();
+
+    TakProtobufCodec codec = TakProtobufCodec.withSchemaFormatter(
+        new CotXmlCodec(),
+        1024 * 1024,
+        descriptorBase64,
+        messageName,
+        protobufSchemaId.toString());
+    Message takMessage = codec.decode(TestProtobufSchemas.encodeProtobufPayload());
+
+    Message cloudEventMessage = new CloudEventJsonTransformation().outgoing(takMessage, "/tak/proto/in");
+    assertNotNull(cloudEventMessage);
+    JsonObject cloudEvent = JsonParser.parseString(new String(cloudEventMessage.getOpaqueData(), StandardCharsets.UTF_8)).getAsJsonObject();
+    JsonObject data = cloudEvent.getAsJsonObject("data");
+
+    assertEquals("1.0", cloudEvent.get("specversion").getAsString());
+    assertEquals("application/json", cloudEvent.get("datacontenttype").getAsString());
+    assertTrue(cloudEvent.has("mapsSchemaId"));
+    assertTrue(data.has("id"));
+    assertEquals("abc", data.get("id").getAsString());
+    assertEquals(123, data.get("count").getAsInt());
+    assertTrue(data.get("active").getAsBoolean());
+    assertEquals("protobuf", cloudEvent.get("mapsMeta_tak_format").getAsString());
+  }
+
+  @Test
+  void cotXmlRoundTripsTakCloudEventTakViaEnvelope() throws Exception {
+    CotXmlCodec codec = new CotXmlCodec();
+    byte[] cotPayload = "<event uid=\"u-xml-2\" type=\"a-f-G-U-C\" time=\"2026-02-19T09:10:00Z\" start=\"2026-02-19T09:10:00Z\" stale=\"2026-02-19T09:15:00Z\" how=\"m-g\"><point lat=\"1\" lon=\"2\" hae=\"3\" ce=\"4\" le=\"5\"/></event>"
+        .getBytes(StandardCharsets.UTF_8);
+    Message takMessage = codec.decode(cotPayload);
+    Message cloudEvent = new CloudEventEnvelopeTransformation().outgoing(takMessage, "/tak/cot/in");
+
+    byte[] encodedBackToTak = codec.encode(cloudEvent);
+    assertArrayEquals(cotPayload, encodedBackToTak);
+
+    Message decodedBack = codec.decode(encodedBackToTak);
+    assertEquals("u-xml-2", decodedBack.getMeta().get("tak.uid"));
+    assertEquals("xml", decodedBack.getMeta().get("tak.format"));
+  }
+
+  @Test
+  void protobufRoundTripsTakCloudEventTakViaNative() throws Exception {
+    protobufSchemaId = UUID.randomUUID();
+    ProtoBufSchemaConfig schema = (ProtoBufSchemaConfig) TestProtobufSchemas.protobufSchemaConfig(protobufSchemaId);
+    schemaManager.addSchema("/tak/proto", schema);
+    String descriptorBase64 = Base64.getEncoder().encodeToString(schema.getProtobufConfig().getDescriptorValue());
+    String messageName = schema.getProtobufConfig().getMessageName();
+
+    TakProtobufCodec codec = TakProtobufCodec.withSchemaFormatter(
+        new CotXmlCodec(),
+        1024 * 1024,
+        descriptorBase64,
+        messageName,
+        protobufSchemaId.toString());
+    byte[] protobufPayload = TestProtobufSchemas.encodeProtobufPayload();
+    Message takMessage = codec.decode(protobufPayload);
+    Message cloudEvent = new CloudEventNativeTransformation().outgoing(takMessage, "/tak/proto/in");
+
+    byte[] encodedBackToTak = codec.encode(cloudEvent);
+    assertArrayEquals(protobufPayload, encodedBackToTak);
+
+    Message decodedBack = codec.decode(encodedBackToTak);
+    assertEquals("protobuf", decodedBack.getMeta().get("tak.format"));
+  }
+
+  @Test
+  void cotXmlToCloudEventToTakProtobufToCloudEventToCotXml() throws Exception {
+    protobufSchemaId = UUID.randomUUID();
+    ProtoBufSchemaConfig schema = (ProtoBufSchemaConfig) TestProtobufSchemas.protobufSchemaConfig(protobufSchemaId);
+    schemaManager.addSchema("/tak/proto", schema);
+    String descriptorBase64 = Base64.getEncoder().encodeToString(schema.getProtobufConfig().getDescriptorValue());
+    String messageName = schema.getProtobufConfig().getMessageName();
+
+    CotXmlCodec xmlCodec = new CotXmlCodec();
+    TakProtobufCodec protobufCodec = TakProtobufCodec.withSchemaFormatter(
+        new CotXmlCodec(),
+        1024 * 1024,
+        descriptorBase64,
+        messageName,
+        protobufSchemaId.toString());
+
+    byte[] startXml = "<event uid=\"u-chain-1\" type=\"a-f-G-U-C\" time=\"2026-02-19T09:10:00Z\" start=\"2026-02-19T09:10:00Z\" stale=\"2026-02-19T09:15:00Z\" how=\"m-g\"><point lat=\"10.1\" lon=\"11.2\" hae=\"12.3\" ce=\"13.4\" le=\"14.5\"/></event>"
+        .getBytes(StandardCharsets.UTF_8);
+    Message takXmlMessage = xmlCodec.decode(startXml);
+
+    Message cloudEventFromXml = new CloudEventEnvelopeTransformation().outgoing(takXmlMessage, "/tak/cot/in");
+    byte[] takProtobufBytes = protobufCodec.encode(cloudEventFromXml);
+    Message takProtobufMessage = protobufCodec.decode(takProtobufBytes);
+
+    Message cloudEventFromProtobuf = new CloudEventNativeTransformation().outgoing(takProtobufMessage, "/tak/proto/in");
+    byte[] endXml = xmlCodec.encode(cloudEventFromProtobuf);
+    Message decodedEndXml = xmlCodec.decode(endXml);
+
+    assertEquals("u-chain-1", decodedEndXml.getMeta().get("tak.uid"));
+    assertEquals("a-f-G-U-C", decodedEndXml.getMeta().get("tak.type"));
+    assertEquals("10.1", decodedEndXml.getMeta().get("tak.lat"));
+    assertEquals("11.2", decodedEndXml.getMeta().get("tak.lon"));
+    assertEquals("xml", decodedEndXml.getMeta().get("tak.format"));
+  }
+}

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/tak/TakExtensionTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/tak/TakExtensionTest.java
@@ -55,6 +55,12 @@ class TakExtensionTest {
     config.put("multicast_read_buffer_bytes", 2048);
     config.put("protobuf_descriptor_base64", "AQID");
     config.put("protobuf_message_name", "TakMessage");
+    config.put("xml_schema_id", "10000000-0000-1000-a000-100000000004");
+    config.put("protobuf_schema_id", "f4f6f837-89ce-4cca-b74d-aa14513c501f");
+    config.put("xml_namespace_aware", false);
+    config.put("xml_coalescing", false);
+    config.put("xml_validating", true);
+    config.put("xml_root_entry", "cotEvent");
     setField(dto, "config", config);
 
     TakExtensionConfig parsed = TakExtensionConfig.from(dto);
@@ -77,6 +83,12 @@ class TakExtensionTest {
     assertEquals(2048, parsed.getMulticastReadBufferBytes());
     assertEquals("AQID", parsed.getProtobufDescriptorBase64());
     assertEquals("TakMessage", parsed.getProtobufMessageName());
+    assertEquals("10000000-0000-1000-a000-100000000004", parsed.getXmlSchemaId());
+    assertEquals("f4f6f837-89ce-4cca-b74d-aa14513c501f", parsed.getProtobufSchemaId());
+    assertFalse(parsed.isXmlNamespaceAware());
+    assertFalse(parsed.isXmlCoalescing());
+    assertTrue(parsed.isXmlValidating());
+    assertEquals("cotEvent", parsed.getXmlRootEntry());
   }
 
   @Test
@@ -94,6 +106,12 @@ class TakExtensionTest {
     assertEquals(6969, parsed.getMulticastPort());
     assertEquals("", parsed.getProtobufDescriptorBase64());
     assertEquals("", parsed.getProtobufMessageName());
+    assertEquals("", parsed.getXmlSchemaId());
+    assertEquals("", parsed.getProtobufSchemaId());
+    assertTrue(parsed.isXmlNamespaceAware());
+    assertTrue(parsed.isXmlCoalescing());
+    assertFalse(parsed.isXmlValidating());
+    assertEquals("event", parsed.getXmlRootEntry());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- align TAK implementation with MAPS extension/factory conventions
- add selector-friendly TAK metadata aliases (tak_type, etc.)
- account multicast read/write bytes in endpoint stats
- improve NetworkConnectionManager.yaml TAK example defaults and selector usage
- add TAK <-> CloudEvent roundtrip coverage, including chained XML -> CE -> Protobuf -> CE -> XML
- add CloudEvent payload extraction helper for TAK codecs

## Validation
- mvn -q -Dtest=io.mapsmessaging.network.protocol.impl.tak.TakExtensionTest,io.mapsmessaging.network.protocol.impl.tak.codec.CotXmlCodecTest,io.mapsmessaging.network.protocol.impl.tak.codec.TakProtobufCodecTest,io.mapsmessaging.network.protocol.impl.tak.framing.TakStreamFramerTest,io.mapsmessaging.network.protocol.impl.tak.framing.TakStreamFramerXmlTest,io.mapsmessaging.api.transformers.TakToCloudEventTransformationTest test
- mvn -q -DskipTests compile