### PR TITLE
Development schema config load

### DIFF
--- a/src/main/java/io/mapsmessaging/analytics/impl/StatisticalAnalyser.java
+++ b/src/main/java/io/mapsmessaging/analytics/impl/StatisticalAnalyser.java
@@ -31,6 +31,7 @@ import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.selector.IdentifierResolver;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,11 @@ public class StatisticalAnalyser implements Analyser {
   public Message ingest(@NotNull Message event) {
     if(formatter == null) {
       String schemaId = event.getSchemaId();
-      formatter = SchemaManager.getInstance().getMessageFormatter(schemaId);
+      try {
+        formatter = SchemaManager.getInstance().getMessageFormatter(schemaId);
+      } catch (IOException e) {
+        // log
+      }
     }
     if(formatter != null) {
       IdentifierResolver resolver = formatter.parse(event.getOpaqueData());

--- a/src/main/java/io/mapsmessaging/api/message/Filter.java
+++ b/src/main/java/io/mapsmessaging/api/message/Filter.java
@@ -27,6 +27,7 @@ import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.selector.IdentifierResolver;
 import io.mapsmessaging.selector.operators.ParserExecutor;
 
+import java.io.IOException;
 import java.util.List;
 
 @SuppressWarnings("java:S6548") // yes it is a singleton
@@ -75,9 +76,13 @@ public class Filter {
   }
 
   public static IdentifierResolver getResolver(String lookup, Message message) {
-    MessageFormatter formatter = SchemaManager.getInstance().getMessageFormatter(lookup);
-    if (formatter != null) {
-      return formatter.parse(message.getOpaqueData());
+    try {
+      MessageFormatter formatter = SchemaManager.getInstance().getMessageFormatter(lookup);
+      if (formatter != null) {
+        return formatter.parse(message.getOpaqueData());
+      }
+    } catch (IOException e) {
+      // log
     }
     return null;
   }

--- a/src/main/java/io/mapsmessaging/api/message/Message.java
+++ b/src/main/java/io/mapsmessaging/api/message/Message.java
@@ -28,7 +28,6 @@ import io.mapsmessaging.engine.schema.SchemaManager;
 import io.mapsmessaging.location.LocationManager;
 import io.mapsmessaging.schemas.config.SchemaConfig;
 import io.mapsmessaging.schemas.formatters.MessageFormatter;
-import io.mapsmessaging.schemas.formatters.MessageFormatterFactory;
 import io.mapsmessaging.schemas.formatters.ParsedObject;
 import io.mapsmessaging.selector.IdentifierResolver;
 import io.mapsmessaging.storage.Storable;
@@ -360,7 +359,7 @@ public class Message implements IdentifierResolver, Storable {
       SchemaConfig config = SchemaManager.getInstance().getSchema(schemaId);
       if(config != null){
         try {
-          MessageFormatter formatter = MessageFormatterFactory.getInstance().getFormatter(config);
+          MessageFormatter formatter = SchemaManager.getInstance().getMessageFormatter(config);
           parsedObject = formatter.parse(getOpaqueData());
         } catch (IOException e) {
           parsedObject = null;

--- a/src/main/java/io/mapsmessaging/api/transformers/JsonQueryTransformation.java
+++ b/src/main/java/io/mapsmessaging/api/transformers/JsonQueryTransformation.java
@@ -134,7 +134,7 @@ public class JsonQueryTransformation implements InterServerTransformation {
       if (schemaId != null) {
         SchemaConfig config = SchemaManager.getInstance().getSchema(schemaId);
         try {
-          messageFormatter = MessageFormatterFactory.getInstance().getFormatter(config);
+          messageFormatter = SchemaManager.getInstance().getMessageFormatter(config);
           if (messageFormatter != null) {
             schemaMap.put(source, messageFormatter);
           }

--- a/src/main/java/io/mapsmessaging/config/SchemaManagerConfig.java
+++ b/src/main/java/io/mapsmessaging/config/SchemaManagerConfig.java
@@ -57,10 +57,11 @@ public class SchemaManagerConfig extends SchemaManagerConfigDTO implements Confi
   }
 
   private void loadLocations(ConfigurationProperties props){
-    if(props.containsKey("path") && props.containsKey("format")){
+    if(props.containsKey("path") && props.containsKey("format") && props.containsKey("name")){
       SchemaImportLocationDTO locationDTO = new SchemaImportLocationDTO();
       locationDTO.setPath(props.getProperty("path"));
       locationDTO.setFormat(props.getProperty("format"));
+      locationDTO.setName(props.getProperty("name"));
       super.getImportLocations().add(locationDTO);
     }
   }

--- a/src/main/java/io/mapsmessaging/config/SchemaManagerConfig.java
+++ b/src/main/java/io/mapsmessaging/config/SchemaManagerConfig.java
@@ -28,6 +28,7 @@ import io.mapsmessaging.license.FeatureManager;
 import io.mapsmessaging.utilities.configuration.ConfigurationManager;
 
 import java.io.IOException;
+import java.util.List;
 
 public class SchemaManagerConfig extends SchemaManagerConfigDTO implements Config, ConfigManager {
 
@@ -40,6 +41,27 @@ public class SchemaManagerConfig extends SchemaManagerConfigDTO implements Confi
       case "file" -> super.setRepositoryConfig(configureFile( (ConfigurationProperties) configurationProperties.get("config")));
       case "maps" -> super.setRepositoryConfig(configureMaps( (ConfigurationProperties) configurationProperties.get("config")));
       default -> super.setRepositoryConfig(new SimpleRepositoryConfigDTO());
+    }
+    Object locations = configurationProperties.get("importLocations");
+    if(locations instanceof List list){
+      for(Object location : list){
+        if(location instanceof ConfigurationProperties props){
+          loadLocations(props);
+        }
+      }
+    }
+    else if(locations instanceof ConfigurationProperties props){
+      loadLocations(props);
+    }
+    setProtocPath(configurationProperties.getProperty("protocPath", null));
+  }
+
+  private void loadLocations(ConfigurationProperties props){
+    if(props.containsKey("path") && props.containsKey("format")){
+      SchemaImportLocationDTO locationDTO = new SchemaImportLocationDTO();
+      locationDTO.setPath(props.getProperty("path"));
+      locationDTO.setFormat(props.getProperty("format"));
+      super.getImportLocations().add(locationDTO);
     }
   }
 

--- a/src/main/java/io/mapsmessaging/dto/rest/schema/SchemaImportLocationDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/schema/SchemaImportLocationDTO.java
@@ -32,6 +32,15 @@ import lombok.NoArgsConstructor;
 public class SchemaImportLocationDTO {
 
   @Schema(
+      description = "Name to apply to the schema when loaded",
+      requiredMode = Schema.RequiredMode.REQUIRED,
+      nullable = false,
+      example = "protobuf_schema_1"
+  )
+  private String name;
+
+
+  @Schema(
       description = "Directory path containing schema files",
       requiredMode = Schema.RequiredMode.REQUIRED,
       nullable = false,

--- a/src/main/java/io/mapsmessaging/dto/rest/schema/SchemaImportLocationDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/schema/SchemaImportLocationDTO.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.dto.rest.schema;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Schema(
+    title = "Schema Import Location",
+    description = "Defines a directory path and the schema format to load from that directory")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchemaImportLocationDTO {
+
+  @Schema(
+      description = "Directory path containing schema files",
+      requiredMode = Schema.RequiredMode.REQUIRED,
+      nullable = false,
+      example = "/opt/schema/protobuf"
+  )
+  private String path;
+
+  @Schema(
+      description = "Schema format contained in the directory",
+      requiredMode = Schema.RequiredMode.REQUIRED,
+      nullable = false,
+      allowableValues = {
+          "protobuf",
+          "json"
+      },
+      example = "protobuf"
+  )
+  private String format;
+}

--- a/src/main/java/io/mapsmessaging/dto/rest/schema/SchemaManagerConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/schema/SchemaManagerConfigDTO.java
@@ -29,6 +29,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Schema(
     title = "Schema Manager config",
     description = "Configures the schema manager on where it can find and store schemas")
@@ -56,6 +59,25 @@ public class SchemaManagerConfigDTO extends BaseManagerConfigDTO {
       }
   )
   private RepositoryConfigDTO repositoryConfig;
+
+
+  @Schema(
+      description = "Optional path to the protoc compiler executable. " +
+          "If not supplied the system PATH will be used.",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
+      example = "/usr/local/bin/protoc"
+  )
+  private String protocPath;
+
+  @Schema(
+      description = "List of directories that are scanned for schema source files such as protobuf or JSON schemas. " +
+          "These schemas are loaded and exposed as built-in or well-known schemas.",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true
+  )
+  private List<SchemaImportLocationDTO> importLocations = new ArrayList<>();
+
 
   public SchemaManagerConfigDTO() {
     super("SchemaManagerConfigDTO");

--- a/src/main/java/io/mapsmessaging/engine/schema/MessageSchemaToJsonBuilder.java
+++ b/src/main/java/io/mapsmessaging/engine/schema/MessageSchemaToJsonBuilder.java
@@ -36,7 +36,7 @@ public class MessageSchemaToJsonBuilder {
     if(schemaId != null && !destinationName.startsWith("$")) {
       SchemaConfig config = SchemaManager.getInstance().getSchema(schemaId);
       if(config != null) {
-        MessageFormatter formatter = MessageFormatterFactory.getInstance().getFormatter(config);
+        MessageFormatter formatter = SchemaManager.getInstance().getMessageFormatter(config);
         if (formatter != null && !(formatter instanceof RawFormatter)) {
           byte[] data = pack(message, config, formatter);
           MessageBuilder messageBuilder = new MessageBuilder();

--- a/src/main/java/io/mapsmessaging/engine/schema/SchemaManager.java
+++ b/src/main/java/io/mapsmessaging/engine/schema/SchemaManager.java
@@ -37,6 +37,7 @@ import io.mapsmessaging.schemas.config.impl.NativeSchemaConfig.TYPE;
 import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.schemas.formatters.MessageFormatterFactory;
 import io.mapsmessaging.schemas.repository.SchemaRepository;
+import io.mapsmessaging.schemas.repository.SchemaResolver;
 import io.mapsmessaging.schemas.repository.impl.FileSchemaRepository;
 import io.mapsmessaging.schemas.repository.impl.RestSchemaRepository;
 import io.mapsmessaging.schemas.repository.impl.SimpleSchemaRepository;
@@ -54,7 +55,7 @@ import java.util.Map.Entry;
 import static io.mapsmessaging.logging.ServerLogMessages.*;
 
 @SuppressWarnings("java:S6548") // yes, it is a singleton
-public class SchemaManager implements Agent {
+public class SchemaManager implements Agent, SchemaResolver {
   private static final String MONITOR = "monitor";
 
   public static final UUID DEFAULT_RAW_UUID =              UUID.fromString("10000000-0000-1000-a000-100000000000");
@@ -76,6 +77,7 @@ public class SchemaManager implements Agent {
   private final Map<String, MessageFormatter> loadedFormatter;
   private final Map<String, List<SchemaConfig>> pathMap;
   private final List<SchemaImportLocationDTO> importLocations = new ArrayList<>();
+  private final Map<String, SchemaConfig> preLoadedSchemas = new HashMap<>();
   private final String protocPath;
 
   @Getter
@@ -92,14 +94,6 @@ public class SchemaManager implements Agent {
     }
     List<SchemaConfig> list = pathMap.computeIfAbsent(path, k -> new ArrayList<>());
     list.add(schemaConfig);
-    try {
-      if (!loadedFormatter.containsKey(schemaConfig.getUniqueId())) {
-        MessageFormatter messageFormatter = MessageFormatterFactory.getInstance().getFormatter(schemaConfig);
-        loadedFormatter.put(schemaConfig.getUniqueId(), messageFormatter);
-      }
-    } catch (Exception e) {
-      // Unable to load the formatter
-    }
     updateCount++;
     return resource.getDefaultVersion();
   }
@@ -119,18 +113,17 @@ public class SchemaManager implements Agent {
     };
   }
 
-  public MessageFormatter getMessageFormatter(String uniqueId) {
+  public MessageFormatter getMessageFormatter(SchemaConfig config) throws IOException{
+    return getMessageFormatter(config.getUniqueId());
+  }
+
+  public MessageFormatter getMessageFormatter(String uniqueId) throws IOException {
     MessageFormatter formatter = loadedFormatter.get(uniqueId);
     if(formatter == null){
       SchemaConfig schemaConfig = getSchema(uniqueId);
       if(schemaConfig != null) {
-        try {
-          formatter = MessageFormatterFactory.getInstance().getFormatter(schemaConfig);
-          loadedFormatter.put(schemaConfig.getUniqueId(), formatter);
-        } catch (IOException e) {
-          // log this
-        }
-
+        formatter = MessageFormatterFactory.getInstance().getFormatter(schemaConfig, this);
+        loadedFormatter.put(schemaConfig.getUniqueId(), formatter);
       }
     }
     return formatter;
@@ -139,7 +132,6 @@ public class SchemaManager implements Agent {
   public List<String> getMessageFormats() {
     return MessageFormatterFactory.getInstance().getFormatters();
   }
-
 
   public synchronized SchemaConfig getSchema(UUID uniqueId) {
     return getSchema(uniqueId.toString());
@@ -151,6 +143,11 @@ public class SchemaManager implements Agent {
       return resource.getDefaultVersion();
     }
     return null;
+  }
+
+
+  public synchronized SchemaConfig getSchemaByName(String name) {
+    return preLoadedSchemas.get(name);
   }
 
   public synchronized SchemaConfig locateSchema(String destinationName) {
@@ -279,6 +276,8 @@ public class SchemaManager implements Agent {
         try {
           JsonSchemaConfig jsonSchemaConfig1 = new JsonSchemaConfig(Path.of(location.getPath()));
           addSchema(location.getName(), jsonSchemaConfig1);
+          loadBundle(jsonSchemaConfig1);
+          preLoadedSchemas.put(location.getName(), jsonSchemaConfig1);
           logger.log(SCHEMA_MANAGER_LOADED_CONFIG,location.getName(), jsonSchemaConfig1.getUniqueId(), jsonSchemaConfig1.getFormat());
         } catch (IOException e) {
           logger.log(SCHEMA_MANAGER_LOADED_CONFIG_FAILED, location.getPath(), location.getFormat(), e);
@@ -289,6 +288,8 @@ public class SchemaManager implements Agent {
           List<ProtoBufSchemaConfig> schemaList = ProtobufSchemaGenerator.loadSchemas(Path.of(location.getPath()), protoExec);
           for(ProtoBufSchemaConfig schema: schemaList){
             addSchema(location.getName(), schema);
+            loadBundle(schema);
+            preLoadedSchemas.put(location.getName(), schema);
             logger.log(SCHEMA_MANAGER_LOADED_CONFIG,location.getName(), schema.getUniqueId(), schema.getFormat());
           }
         } catch (IOException e) {
@@ -296,12 +297,34 @@ public class SchemaManager implements Agent {
         }
       }
     }
-
     // This ensures the factory is loaded
     MessageFormatterFactory.getInstance();
   }
 
+  @Override
+  public SchemaConfig resolveParent(SchemaConfig schemaConfig) {
+    SchemaResource resource = repository.getResource(schemaConfig.getUniqueId());
+    if(resource != null){
+      return resource.getDefaultVersion();
+    }
+    return null;
+  }
+
+
+  private void loadBundle(SchemaConfig schema){
+    if(schema.isBundle()){
+      for (SchemaConfig config : schema.getBundledSchemas()) {
+        logger.log(SCHEMA_MANAGER_LOADED_BUNDLED, config.getName(), schema.getName(), schema.getUniqueId(), schema.getFormat());
+        repository.addVersion(config.getUniqueId(), config);
+      }
+    }
+  }
+
+
   private SchemaManager() {
+    loadedFormatter = new LinkedHashMap<>();
+    pathMap = new LinkedHashMap<>();
+
     SchemaManagerConfig config;
     try {
       config = ConfigurationManager.getInstance().getConfiguration(SchemaManagerConfig.class);
@@ -321,12 +344,16 @@ public class SchemaManager implements Agent {
     else{
       buildTime = new SimpleSchemaRepository();
     }
-    protocPath = config.getProtocPath();
     repository = buildTime;
-    loadedFormatter = new LinkedHashMap<>();
-    pathMap = new LinkedHashMap<>();
-    if(config != null && config.getImportLocations() != null) {
-      importLocations.addAll(config.getImportLocations());
+
+    if(config != null){
+      protocPath = config.getProtocPath();
+      if(config.getImportLocations() != null) {
+        importLocations.addAll(config.getImportLocations());
+      }
+    }
+    else{
+      protocPath = null;
     }
   }
 

--- a/src/main/java/io/mapsmessaging/engine/schema/SchemaManager.java
+++ b/src/main/java/io/mapsmessaging/engine/schema/SchemaManager.java
@@ -25,31 +25,35 @@ import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.dto.rest.schema.FileRepositoryConfigDTO;
 import io.mapsmessaging.dto.rest.schema.MapsRepositoryConfigDTO;
 import io.mapsmessaging.dto.rest.schema.RepositoryConfigDTO;
+import io.mapsmessaging.dto.rest.schema.SchemaImportLocationDTO;
 import io.mapsmessaging.dto.rest.system.Status;
 import io.mapsmessaging.dto.rest.system.SubSystemStatusDTO;
+import io.mapsmessaging.logging.Logger;
+import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.schemas.config.SchemaConfig;
 import io.mapsmessaging.schemas.config.SchemaResource;
-import io.mapsmessaging.schemas.config.impl.JsonSchemaConfig;
-import io.mapsmessaging.schemas.config.impl.NativeSchemaConfig;
+import io.mapsmessaging.schemas.config.impl.*;
 import io.mapsmessaging.schemas.config.impl.NativeSchemaConfig.TYPE;
-import io.mapsmessaging.schemas.config.impl.RawSchemaConfig;
-import io.mapsmessaging.schemas.config.impl.XmlSchemaConfig;
 import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.schemas.formatters.MessageFormatterFactory;
 import io.mapsmessaging.schemas.repository.SchemaRepository;
 import io.mapsmessaging.schemas.repository.impl.FileSchemaRepository;
 import io.mapsmessaging.schemas.repository.impl.RestSchemaRepository;
 import io.mapsmessaging.schemas.repository.impl.SimpleSchemaRepository;
+import io.mapsmessaging.schemas.tools.protobuf.ProtobufSchemaGenerator;
 import io.mapsmessaging.utilities.Agent;
 import io.mapsmessaging.utilities.configuration.ConfigurationManager;
 import lombok.Getter;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.Map.Entry;
 
-@SuppressWarnings("java:S6548") // yes it is a singleton
+import static io.mapsmessaging.logging.ServerLogMessages.*;
+
+@SuppressWarnings("java:S6548") // yes, it is a singleton
 public class SchemaManager implements Agent {
   private static final String MONITOR = "monitor";
 
@@ -67,9 +71,12 @@ public class SchemaManager implements Agent {
     return Holder.INSTANCE;
   }
 
+  private final Logger logger = LoggerFactory.getLogger(getClass());
   private final SchemaRepository repository;
   private final Map<String, MessageFormatter> loadedFormatter;
   private final Map<String, List<SchemaConfig>> pathMap;
+  private final List<SchemaImportLocationDTO> importLocations = new ArrayList<>();
+  private final String protocPath;
 
   @Getter
   private long updateCount = 0;
@@ -218,6 +225,7 @@ public class SchemaManager implements Agent {
   }
 
   public void start() {
+    logger.log(SCHEMA_MANAGER_STARTUP);
     SchemaConfig rawConfig = new RawSchemaConfig();
     rawConfig.setUniqueId(DEFAULT_RAW_UUID);
     rawConfig.setVersion(1);
@@ -264,6 +272,31 @@ public class SchemaManager implements Agent {
     xmlSchemaConfig.setSchema(new JsonObject());
     addSchema("$SYS", xmlSchemaConfig);
 
+    Path protoExec = protocPath == null? null: Path.of(protocPath);
+
+    for(SchemaImportLocationDTO location: importLocations){
+      if(location.getFormat().equalsIgnoreCase("json")){
+        try {
+          JsonSchemaConfig jsonSchemaConfig1 = new JsonSchemaConfig(Path.of(location.getPath()));
+          addSchema(location.getPath(), jsonSchemaConfig1);
+          logger.log(SCHEMA_MANAGER_LOADED_CONFIG,jsonSchemaConfig1.getName(), jsonSchemaConfig1.getUniqueId(), jsonSchemaConfig1.getFormat());
+        } catch (IOException e) {
+          logger.log(SCHEMA_MANAGER_LOADED_CONFIG_FAILED, location.getPath(), location.getFormat(), e);
+        }
+      }
+      else if(location.getFormat().equalsIgnoreCase("protobuf")){
+        try {
+          List<ProtoBufSchemaConfig> schemaList = ProtobufSchemaGenerator.loadSchemas(Path.of(location.getPath()), protoExec);
+          for(ProtoBufSchemaConfig schema: schemaList){
+            addSchema(schema.getName(), schema);
+            logger.log(SCHEMA_MANAGER_LOADED_CONFIG,schema.getName(), schema.getUniqueId(), schema.getFormat());
+          }
+        } catch (IOException e) {
+          logger.log(SCHEMA_MANAGER_LOADED_CONFIG_FAILED, location.getPath(), location.getFormat(), e);
+        }
+      }
+    }
+
     // This ensures the factory is loaded
     MessageFormatterFactory.getInstance();
   }
@@ -288,9 +321,13 @@ public class SchemaManager implements Agent {
     else{
       buildTime = new SimpleSchemaRepository();
     }
+    protocPath = config.getProtocPath();
     repository = buildTime;
     loadedFormatter = new LinkedHashMap<>();
     pathMap = new LinkedHashMap<>();
+    if(config != null && config.getImportLocations() != null) {
+      importLocations.addAll(config.getImportLocations());
+    }
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/engine/schema/SchemaManager.java
+++ b/src/main/java/io/mapsmessaging/engine/schema/SchemaManager.java
@@ -278,8 +278,8 @@ public class SchemaManager implements Agent {
       if(location.getFormat().equalsIgnoreCase("json")){
         try {
           JsonSchemaConfig jsonSchemaConfig1 = new JsonSchemaConfig(Path.of(location.getPath()));
-          addSchema(location.getPath(), jsonSchemaConfig1);
-          logger.log(SCHEMA_MANAGER_LOADED_CONFIG,jsonSchemaConfig1.getName(), jsonSchemaConfig1.getUniqueId(), jsonSchemaConfig1.getFormat());
+          addSchema(location.getName(), jsonSchemaConfig1);
+          logger.log(SCHEMA_MANAGER_LOADED_CONFIG,location.getName(), jsonSchemaConfig1.getUniqueId(), jsonSchemaConfig1.getFormat());
         } catch (IOException e) {
           logger.log(SCHEMA_MANAGER_LOADED_CONFIG_FAILED, location.getPath(), location.getFormat(), e);
         }
@@ -288,8 +288,8 @@ public class SchemaManager implements Agent {
         try {
           List<ProtoBufSchemaConfig> schemaList = ProtobufSchemaGenerator.loadSchemas(Path.of(location.getPath()), protoExec);
           for(ProtoBufSchemaConfig schema: schemaList){
-            addSchema(schema.getName(), schema);
-            logger.log(SCHEMA_MANAGER_LOADED_CONFIG,schema.getName(), schema.getUniqueId(), schema.getFormat());
+            addSchema(location.getName(), schema);
+            logger.log(SCHEMA_MANAGER_LOADED_CONFIG,location.getName(), schema.getUniqueId(), schema.getFormat());
           }
         } catch (IOException e) {
           logger.log(SCHEMA_MANAGER_LOADED_CONFIG_FAILED, location.getPath(), location.getFormat(), e);

--- a/src/main/java/io/mapsmessaging/logging/ServerLogMessages.java
+++ b/src/main/java/io/mapsmessaging/logging/ServerLogMessages.java
@@ -740,7 +740,8 @@ public enum ServerLogMessages implements LogMessage {
 
   //<editor-fold desc="Schema Manager, log messages">
   SCHEMA_MANAGER_STARTUP(LEVEL.INFO, SERVER_CATEGORY.ENGINE, "Schema Manager starting up"),
-  SCHEMA_MANAGER_LOADED_CONFIG(LEVEL.WARN, SERVER_CATEGORY.ENGINE, "Loaded configuration from file name:{} UUID:{} type:{}"),
+  SCHEMA_MANAGER_LOADED_CONFIG(LEVEL.INFO, SERVER_CATEGORY.ENGINE, "Loaded configuration from file name:{} UUID:{} type:{}"),
+  SCHEMA_MANAGER_LOADED_BUNDLED(LEVEL.INFO, SERVER_CATEGORY.ENGINE, "Loaded bundled schema {} from name:{} UUID:{} type:{} "),
   SCHEMA_MANAGER_LOADED_CONFIG_FAILED(LEVEL.WARN, SERVER_CATEGORY.ENGINE, "Failed to loaded configuration from file {} of type:{}"),
   //</editor-fold>
 

--- a/src/main/java/io/mapsmessaging/logging/ServerLogMessages.java
+++ b/src/main/java/io/mapsmessaging/logging/ServerLogMessages.java
@@ -738,6 +738,13 @@ public enum ServerLogMessages implements LogMessage {
   COAP_BLOCK2_REQUEST(LEVEL.TRACE, SERVER_CATEGORY.PROTOCOL, "Block2 packet received, Message No: {}, Block Size: {}, has more:{}"),
   //</editor-fold>
 
+  //<editor-fold desc="Schema Manager, log messages">
+  SCHEMA_MANAGER_STARTUP(LEVEL.INFO, SERVER_CATEGORY.ENGINE, "Schema Manager starting up"),
+  SCHEMA_MANAGER_LOADED_CONFIG(LEVEL.WARN, SERVER_CATEGORY.ENGINE, "Loaded configuration from file name:{} UUID:{} type:{}"),
+  SCHEMA_MANAGER_LOADED_CONFIG_FAILED(LEVEL.WARN, SERVER_CATEGORY.ENGINE, "Failed to loaded configuration from file {} of type:{}"),
+  //</editor-fold>
+
+
   //<editor-fold desc="Device Integration, log messages">
   DEVICE_SELECTOR_PARSER_EXCEPTION(LEVEL.INFO, SERVER_CATEGORY.DEVICE, "Selection {}, failed to parse with the following exception {}"),
   DEVICE_SCHEMA_UPDATED(LEVEL.WARN, SERVER_CATEGORY.DEVICE, "Device {} schema configuration updated"),
@@ -748,8 +755,6 @@ public enum ServerLogMessages implements LogMessage {
   DEVICE_STOP(LEVEL.INFO, SERVER_CATEGORY.DEVICE, "Stopping device {}"),
   DEVICE_SCHEDULE_TASK_FAILED(LEVEL.WARN, SERVER_CATEGORY.DEVICE, "Scheduled task for device failed"),
   DEVICE_SCHEDULE_TASK_EXCCEDED_TIME(LEVEL.INFO, SERVER_CATEGORY.DEVICE, "Scheduled task exceeded time limit, took {}ms"),
-
-
   DEVICE_MANAGER_STARTUP(LEVEL.DEBUG, SERVER_CATEGORY.ENGINE, "Starting Device Manager"),
   DEVICE_MANAGER_STARTUP_FAILED(LEVEL.WARN, SERVER_CATEGORY.ENGINE, "Device Manager failed to start"),
   DEVICE_MANAGER_FAILED_TO_REGISTER(LEVEL.INFO, SERVER_CATEGORY.DEVICE, "Failed to register device"),

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/n2k/N2kProtocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/n2k/N2kProtocol.java
@@ -96,7 +96,7 @@ public class N2kProtocol extends Protocol {
     rawTopicTemplate =  ((N2KConfigDTO)protocolConfig).getUnknownPacketTopic().replace("{candevice}",endPoint.getName());
     parseToJson =((N2KConfigDTO)protocolConfig).isParseToJson();
     String inboundTopicName =((N2KConfigDTO)protocolConfig).getInboundTopicName();
-    formatter = (CanbusFormatter) MessageFormatterFactory.getInstance().getFormatter(canbusSchema);
+    formatter = (CanbusFormatter) SchemaManager.getInstance().getMessageFormatter(canbusSchema);
     try {
       session = buildSession(endPoint.getName(), 10000);
     } catch (ExecutionException | TimeoutException e) {

--- a/src/main/java/io/mapsmessaging/network/protocol/transformation/cloudevent/pack/PackHelper.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/transformation/cloudevent/pack/PackHelper.java
@@ -76,7 +76,7 @@ public abstract class PackHelper {
     MessageFormatter formatter = null;
     if (schemaConfig != null) {
       try {
-        formatter = MessageFormatterFactory.getInstance().getFormatter(schemaConfig);
+        formatter = SchemaManager.getInstance().getMessageFormatter(schemaConfig);
       } catch (Exception ignore) {
         // if we can not parse to json, we fall through and base64 it
       }

--- a/src/main/java/io/mapsmessaging/rest/api/impl/messaging/impl/RestMessageListener.java
+++ b/src/main/java/io/mapsmessaging/rest/api/impl/messaging/impl/RestMessageListener.java
@@ -236,7 +236,7 @@ public class RestMessageListener implements MessageListener {
     if(message.getMessage().getSchemaId() != null) {
       SchemaConfig config = SchemaManager.getInstance().getSchema(message.getMessage().getSchemaId());
       try {
-        MessageFormatter formatter = MessageFormatterFactory.getInstance().getFormatter(config);
+        MessageFormatter formatter = SchemaManager.getInstance().getMessageFormatter(config);
         if (formatter != null && !(formatter instanceof RawFormatter)) {
           JsonObject jsonObject = formatter.parseToJson(payload);
           JsonObject wrapper = new JsonObject();

--- a/src/test/java/io/mapsmessaging/api/transformers/JsonQueryTransformationTest.java
+++ b/src/test/java/io/mapsmessaging/api/transformers/JsonQueryTransformationTest.java
@@ -20,6 +20,7 @@
 package io.mapsmessaging.api.transformers;
 
 import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.engine.schema.SchemaManager;
 import io.mapsmessaging.engine.transformers.TransformerManager;
 import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.schemas.formatters.MessageFormatterFactory;
@@ -56,7 +57,7 @@ class JsonQueryTransformationTest extends AbstractDroppingTransformationTest {
   private void setMessageFormatter(InterServerTransformation transformation) {
     try {
       MessageFormatter messageFormatter =
-          MessageFormatterFactory.getInstance().getFormatter(AbstractInterServerTransformationTest.JSON_SCHEMA_CONFIG);
+          SchemaManager.getInstance().getMessageFormatter(AbstractInterServerTransformationTest.JSON_SCHEMA_CONFIG);
       ((JsonQueryTransformation) transformation).schemaMap.put(AbstractInterServerTransformationTest.SOURCE, messageFormatter);
     } catch (IOException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
# Support bundle schemas and child schema resolution

## Overview

This change adds support for **schema bundles** in the server so that a single schema document can expose multiple usable schemas.

Two common cases are now supported:

- **Protobuf descriptor bundles** containing many message types
- **JSON schemas containing `$defs` definitions**

Instead of requiring each message type or definition to be stored as an individual schema, the server now:

1. Loads the **bundle schema**
2. Extracts **child schemas** from the bundle
3. Registers those children in the schema repository
4. Resolves the correct schema at message parse time

This allows topics to bind directly to **individual message types or `$defs` entries** while still using the original bundle schema as the source of truth.

---

## Key Changes

### Schema bundle expansion

When a schema is loaded:

#### Protobuf

Descriptor sets are inspected and **all message definitions are extracted**.

Each message type becomes a **child schema** that references the parent descriptor bundle.

Example:

```text
bundle.desc
 ├── package.Track
 ├── package.CommonHeader
 └── package.Telemetry
```

Each message is registered as a schema referencing the same descriptor bundle.

#### JSON

JSON schemas containing `$defs` are treated as bundles.

Each `$defs` entry becomes a **child schema** referencing the parent schema via JSON Pointer.

Example:

```text
schema.json
$defs:
  Track
  CommonHeader
  Telemetry
```

Children are registered with pointers like:

```text
#/$defs/Track
#/$defs/CommonHeader
#/$defs/Telemetry
```

---

## Parent-Child Schema Model

Child schemas are linked to their parent bundle.

The parent schema stores the actual schema material, while children store:

- the **definition reference**
- the **parent relationship**

This avoids duplicating large schema documents or protobuf descriptors.

---

## Formatter Resolution

Formatter creation now uses a resolver so child schemas can obtain their parent bundle when needed.

```text
SchemaManager
    ↓
SchemaResolver
    ↓
MessageFormatter
```

When parsing a message:

1. The child schema is selected
2. The resolver locates the parent bundle
3. The formatter loads the required definition from the bundle

This ensures:

- protobuf descriptors are not duplicated
- JSON `$ref` resolution continues to work
- validation occurs with full schema context

---

## Topic Binding

Topics can now bind directly to:

- **Protobuf message types**
- **JSON `$defs` definitions**

Example:

```text
Topic: sensors/track
Schema: Track
```

The server resolves `Track` to the correct bundle definition automatically.

---

## Benefits

- Allows large **schema bundles** to be used directly
- Avoids duplicating schema definitions
- Supports **fine-grained schema binding per topic**
- Maintains full schema validation context
- Works for both **Protobuf** and **JSON schemas**

---

## Testing

Tests added for:

- Protobuf message extraction from descriptor bundles
- JSON `$defs` extraction
- JSON pointer resolution
- JSON formatter validation using parent bundle context

---

## Result

The server can now treat schema bundles as **collections of usable schemas**, enabling much simpler schema management for large schema sets.