### PR TITLE
feat(analyser): expose destination topic to Analyser via Message.destinationName

### DIFF
--- a/src/main/java/io/mapsmessaging/api/message/Message.java
+++ b/src/main/java/io/mapsmessaging/api/message/Message.java
@@ -93,6 +93,10 @@ public class Message implements IdentifierResolver, Storable {
   @Getter
   @Setter
   private boolean lastMessage; // This is set via the engine as it is delivered to the client
+
+  @Getter
+  @Setter
+  private transient String destinationName; // Set by the engine before delivering to an Analyser
   // </editor-fold>
   // <editor-fold desc="Persistent data">
   @Getter

--- a/src/main/java/io/mapsmessaging/network/protocol/Protocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/Protocol.java
@@ -309,6 +309,7 @@ public abstract class Protocol implements SelectorCallback, MessageListener, Tim
     }
     Message msg = parsedMessage.getMessage();
     if(analyser != null){
+      msg.setDestinationName(parsedMessage.getDestinationName());
       msg = analyser.ingest(msg);
       if(msg == null){
         return null;


### PR DESCRIPTION
## Summary

- Adds a transient `destinationName` field to `Message`, set by the engine in `Protocol.processMessageAnalyser()` immediately before calling `analyser.ingest()`
- Gives `Analyser` implementations access to the MAPS topic a message arrived on, with no impact on serialisation, persistence, or existing analysers

## Motivation

Currently `Analyser.ingest(Message)` has no way to know which topic the message came from. The engine caches one `Analyser` instance per topic (`topicNameAnalyserMap`), but a router-style analyser that manages multiple per-topic models internally needs the destination at ingest time.

This is needed to support `MicroGptRouterAnalyser` in the upcoming `maps-microgpt-mavlink-demo`: a single Analyser plugin that maintains one micro-GPT model per subscribed topic, routing by `msg.getDestinationName()`.

## Changes

Two files, five lines added:

- `Message.java` — new `@Getter @Setter private transient String destinationName` in the existing transient-data fold (same pattern as `lastMessage` and `bound`)
- `Protocol.java` — one line: `msg.setDestinationName(parsedMessage.getDestinationName())` before `analyser.ingest(msg)`

## Test Plan

- [ ] Existing tests pass (no behavioural change for analysers that ignore `destinationName`)
- [ ] Confirm field is not included in `Message.pack()` / serialisation (it is `transient`)
- [ ] Verify a custom Analyser can read `msg.getDestinationName()` and get the correct MAPS topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)