### PR TITLE
feat(n2k): add configurable modelId and modelSerialCode for PGN 126996

### DIFF
--- a/src/main/java/io/mapsmessaging/config/protocol/impl/N2kProtocolConfig.java
+++ b/src/main/java/io/mapsmessaging/config/protocol/impl/N2kProtocolConfig.java
@@ -37,6 +37,8 @@ public class N2kProtocolConfig extends N2KConfigDTO implements Config {
     this.unknownPacketTopic = config.getProperty("unknownPacketTopic", unknownPacketTopic);
     this.publishMavlinkDrones = config.getBooleanProperty("publishMavlinkDrones", publishMavlinkDrones);
     this.canBusAddress = config.getIntProperty("canBusAddress", canBusAddress);
+    this.modelId = config.getProperty("modelId", "Maps Messaging Server");
+    this.modelSerialCode = config.getProperty("modelSerialCode", "unknown");
   }
 
   @Override
@@ -74,6 +76,8 @@ public class N2kProtocolConfig extends N2KConfigDTO implements Config {
     properties.put("unknownPacketTopic", this.unknownPacketTopic);
     properties.put("publishMavlinkDrones", this.publishMavlinkDrones);
     properties.put("canBusAddress", this.canBusAddress);
+    properties.put("modelId", this.modelId);
+    properties.put("modelSerialCode", this.modelSerialCode);
     return properties;
   }
 }

--- a/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/N2KConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/N2KConfigDTO.java
@@ -114,4 +114,24 @@ public class N2KConfigDTO extends ProtocolConfigDTO {
   )
   protected boolean publishMavlinkDrones = true;
 
+  @Schema(
+      description = "NMEA 2000 model ID reported in PGN 126996 Product Information. "
+          + "Shown on connected chartplotters and MFDs as the device name.",
+      example = "Maps Messaging Server",
+      defaultValue = "Maps Messaging Server",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true
+  )
+  protected String modelId;
+
+  @Schema(
+      description = "NMEA 2000 serial number reported in PGN 126996 Product Information. "
+          + "Shown on connected chartplotters and MFDs as the device serial number.",
+      example = "MAPS-CMRE-001",
+      defaultValue = "unknown",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true
+  )
+  protected String modelSerialCode;
+
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/n2k/N2kProtocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/n2k/N2kProtocol.java
@@ -80,6 +80,8 @@ public class N2kProtocol extends Protocol {
   private final SchemaConfig defaultSchemaConfig = SchemaManager.getInstance().getSchema(DEFAULT_JSON_SCHEMA);
   private final DroneMonitor droneMonitor;
   private final int canbusAddress;
+  private final String modelId;
+  private final String modelSerialCode;
 
   public N2kProtocol(CanbusEndPoint endPoint, @NotNull @NonNull ProtocolConfigDTO protocolConfig) throws IOException {
     super(endPoint, protocolConfig );
@@ -108,6 +110,8 @@ public class N2kProtocol extends Protocol {
     rawTopicTemplate =  n2kConfig.getUnknownPacketTopic().replace("{candevice}",endPoint.getName());
     parseToJson =n2kConfig.isParseToJson();
     canbusAddress = n2kConfig.getCanBusAddress();
+    modelId = n2kConfig.getModelId();
+    modelSerialCode = n2kConfig.getModelSerialCode();
     String inboundTopicName =n2kConfig.getInboundTopicName();
 
     formatter = MessageFormatterFactory.getInstance().getFormatter(canbusSchema);
@@ -239,7 +243,7 @@ public class N2kProtocol extends Protocol {
       byte[] payload = frame.data();
       int requestedPgn = (payload[0] & 0xFF) | ((payload[1] & 0xFF) << 8) | ((payload[2] & 0xFF) << 16);
       AbstractAisFieldValueSource response = switch (requestedPgn) {
-        case 126996 -> new ProductInformationFieldValueSource("Maps Messaging Server", BuildInfo.getBuildVersion(), null, null);
+        case 126996 -> new ProductInformationFieldValueSource(modelId, BuildInfo.getBuildVersion(), null, modelSerialCode);
         case 126998 -> new ConfigurationInformationFieldValueSource();
         case 60928 -> new IsoAddressClaimFieldValueSource(MessageDaemon.getInstance().getUuid().toString());
         default -> null;

--- a/src/test/java/io/mapsmessaging/config/protocol/impl/N2kProtocolConfigTest.java
+++ b/src/test/java/io/mapsmessaging/config/protocol/impl/N2kProtocolConfigTest.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.config.protocol.impl;
+
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class N2kProtocolConfigTest {
+
+  @Test
+  void defaultModelIdIsUsedWhenNotConfigured() {
+    ConfigurationProperties props = new ConfigurationProperties();
+    N2kProtocolConfig config = new N2kProtocolConfig(props);
+    assertEquals("Maps Messaging Server", config.getModelId());
+  }
+
+  @Test
+  void defaultModelSerialCodeIsUsedWhenNotConfigured() {
+    ConfigurationProperties props = new ConfigurationProperties();
+    N2kProtocolConfig config = new N2kProtocolConfig(props);
+    assertEquals("unknown", config.getModelSerialCode());
+  }
+
+  @Test
+  void customModelIdIsReadFromConfig() {
+    ConfigurationProperties props = new ConfigurationProperties();
+    props.put("modelId", "My Custom Device");
+    N2kProtocolConfig config = new N2kProtocolConfig(props);
+    assertEquals("My Custom Device", config.getModelId());
+  }
+
+  @Test
+  void customModelSerialCodeIsReadFromConfig() {
+    ConfigurationProperties props = new ConfigurationProperties();
+    props.put("modelSerialCode", "MAPS-CMRE-001");
+    N2kProtocolConfig config = new N2kProtocolConfig(props);
+    assertEquals("MAPS-CMRE-001", config.getModelSerialCode());
+  }
+
+  @Test
+  void toConfigurationPropertiesRoundTripsModelFields() {
+    ConfigurationProperties props = new ConfigurationProperties();
+    props.put("modelId", "Test Device");
+    props.put("modelSerialCode", "SN-12345");
+    N2kProtocolConfig config = new N2kProtocolConfig(props);
+    ConfigurationProperties out = config.toConfigurationProperties();
+    assertEquals("Test Device", out.getProperty("modelId"));
+    assertEquals("SN-12345", out.getProperty("modelSerialCode"));
+  }
+}


### PR DESCRIPTION
## Summary

- Adds two new optional config fields `modelId` and `modelSerialCode` to N2KConfigDTO (and by inheritance N2kProtocolConfig), read from `NetworkManager.yaml` with sensible defaults
- Wires `modelId` and `modelSerialCode` into `ProductInformationFieldValueSource` when responding to PGN 126996 requests, replacing the hardcoded `"Maps Messaging Server"` string and `null` serial number
- Both fields round-trip through `toConfigurationProperties()` for REST API config management

## Motivation

MAPS broadcasts PGN 126996 (Product Information) on the N2K bus so devices like Lowrance HDS-8 can identify it. Previously the serial number field was `null` → displayed as "unknown" on chartplotters. Operators couldn't distinguish MAPS from other N2K devices on the bus.

## Changes

| File | Change |
|------|--------|
| `N2KConfigDTO.java` | Added `modelId` and `modelSerialCode` fields with `@Schema` annotations (Lombok `@Data` generates getters) |
| `N2kProtocolConfig.java` | Reads fields from config with defaults in constructor; serialises them in `toConfigurationProperties()` |
| `N2kProtocol.java` | Stores `modelId`/`modelSerialCode` as `private final` instance fields; uses them in `handleInboundRequest()` case 126996 |
| `N2kProtocolConfigTest.java` | New test class — 5 unit tests covering defaults, custom values, and round-trip serialisation |

## Operational note

`modelId` and `modelSerialCode` are captured as `private final` fields at protocol construction time. A server restart is required for config changes to take effect. This matches the existing behaviour of `canbusAddress`, `topicTemplate`, and other protocol-level fields.

Note: `N2kProtocolConfig.update()` has a pre-existing type guard bug (`instanceof MavlinkConfigDTO` instead of `instanceof N2KConfigDTO`) that makes the REST live-update path unreachable regardless of this PR. That is out of scope here.

## Test plan

- [ ] `mvn test -Dtest=N2kProtocolConfigTest` — 5/5 pass
- [ ] Deploy new binary to halpi, set `modelId` and `modelSerialCode` in `NetworkManager.yaml`, confirm Lowrance HDS-8 displays the configured values on the device list