### PR TITLE
Add MAVLink mission count message support

### DIFF
--- a/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionCount.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionCount.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.messages;
+
+import com.google.gson.JsonObject;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MavlinkMissionCount implements MavlinkMessage {
+
+  public static final int MESSAGE_ID_MISSION_COUNT = 44;
+
+  private static final int TRANSPORT_SEQUENCE_PLACEHOLDER = 0;
+
+  private String messageType = "MISSION_COUNT";
+  private int messageId = MESSAGE_ID_MISSION_COUNT;
+  private int targetSystem;
+  private int targetComponent;
+  private int count;
+  private int missionType;
+
+  @Override
+  public int getCommand() {
+    return 0;
+  }
+
+  @Override
+  public JsonObject toMavlinkJsonObject() {
+    JsonObject root = new JsonObject();
+    JsonObject header = new JsonObject();
+    JsonObject payload = new JsonObject();
+
+    header.addProperty("version", "V2");
+    header.addProperty("systemId", 0);
+    header.addProperty("componentId", 0);
+    header.addProperty("sequence", TRANSPORT_SEQUENCE_PLACEHOLDER);
+    header.addProperty("messageId", messageId);
+    header.addProperty("signed", false);
+    header.addProperty("incompatibilityFlags", 0);
+    header.addProperty("compatibilityFlags", 0);
+
+    payload.addProperty("target_system", targetSystem);
+    payload.addProperty("target_component", targetComponent);
+    payload.addProperty("count", count);
+    payload.addProperty("mission_type", missionType);
+
+    root.add("header", header);
+    root.add("payload", payload);
+
+    return root;
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionCountFactory.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionCountFactory.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.messages;
+
+public final class MavlinkMissionCountFactory {
+
+  public static final int MAV_MISSION_TYPE_MISSION = 0;
+
+  private MavlinkMissionCountFactory() {
+  }
+
+  public static MavlinkMissionCount mission(int targetSystem, int targetComponent, int count) {
+    if (count < 0 || count > 65_535) {
+      throw new IllegalArgumentException("count must be between 0 and 65535");
+    }
+
+    MavlinkMissionCount missionCount = new MavlinkMissionCount();
+    missionCount.setTargetSystem(targetSystem);
+    missionCount.setTargetComponent(targetComponent);
+    missionCount.setCount(count);
+    missionCount.setMissionType(MAV_MISSION_TYPE_MISSION);
+    return missionCount;
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionCountTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionCountTest.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+class MavlinkMissionCountTest {
+
+  @Test
+  void mission_whenCreated_mapsMissionCountPayload() {
+    MavlinkMissionCount missionCount = MavlinkMissionCountFactory.mission(10, 1, 4);
+
+    JsonObject root = missionCount.toMavlinkJsonObject();
+    JsonObject header = root.getAsJsonObject("header");
+    JsonObject payload = root.getAsJsonObject("payload");
+
+    assertEquals(MavlinkMissionCount.MESSAGE_ID_MISSION_COUNT, header.get("messageId").getAsInt());
+    assertEquals(10, payload.get("target_system").getAsInt());
+    assertEquals(1, payload.get("target_component").getAsInt());
+    assertEquals(4, payload.get("count").getAsInt());
+    assertEquals(MavlinkMissionCountFactory.MAV_MISSION_TYPE_MISSION, payload.get("mission_type").getAsInt());
+  }
+
+  @Test
+  void mission_whenCountIsOutsideUnsignedShort_rejectsRequest() {
+    assertThrows(IllegalArgumentException.class, () -> MavlinkMissionCountFactory.mission(10, 1, -1));
+    assertThrows(IllegalArgumentException.class, () -> MavlinkMissionCountFactory.mission(10, 1, 65_536));
+  }
+}


### PR DESCRIPTION
## Summary

- add a typed MAVLink `MISSION_COUNT` message
- add a factory for standard mission uploads
- validate the unsigned 16-bit mission item count
- add JSON payload regression coverage

## Related adapter change

- Maps-Messaging/stanag-state-adapter#1 uses mission-count framing while dispatching model-generated `UxvNavigationPlan` uploads.

The adapter currently carries a compatibility message so it can build against the existing `4.5.0-SNAPSHOT`; this server change provides the canonical shared implementation on `stanag_development`.

## Validation status

The repository did not run a build workflow for this branch in the connected environment. The message contract and factory have focused JUnit coverage, but the normal Maven/Buildkite build is still required before merge.