### PR TITLE
Track MAVLink mission item reached state

### DIFF
--- a/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
+++ b/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
@@ -19,26 +19,37 @@
 
 package io.mapsmessaging.state.drone.drone;
 
+import static io.mapsmessaging.state.drone.util.SyntheticMmsiGenerator.generateSyntheticMmsi;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.mapsmessaging.state.config.StopActionEnum;
 import io.mapsmessaging.state.config.capability.TaskCapabilities;
 import io.mapsmessaging.state.drone.core.EntityTwin;
 import io.mapsmessaging.state.drone.core.TwinType;
-import io.mapsmessaging.state.drone.model.*;
+import io.mapsmessaging.state.drone.model.Contact;
+import io.mapsmessaging.state.drone.model.DetectionEvent;
+import io.mapsmessaging.state.drone.model.DroneContactManager;
+import io.mapsmessaging.state.drone.model.EnvironmentalState;
+import io.mapsmessaging.state.drone.model.SystemState;
+import io.mapsmessaging.state.drone.model.TimeState;
 import io.mapsmessaging.state.drone.model.autopilot.AutopilotState;
 import io.mapsmessaging.state.mavlink.sender.MavlinkEventListSender;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-
 import java.time.Instant;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import static io.mapsmessaging.state.drone.util.SyntheticMmsiGenerator.generateSyntheticMmsi;
-
-/**
- * Twin representing an unmanned aircraft or vehicle.
- */
+/** Twin representing an unmanned aircraft or vehicle. */
 @ToString(callSuper = true)
 @Data
 @NoArgsConstructor
@@ -140,6 +151,12 @@ public class DroneTwin extends EntityTwin {
   @Schema(description = "Current mission sequence number.", example = "12", nullable = true)
   private Integer currentMissionSequence;
 
+  @Schema(description = "Sequence number of the most recently reached MAVLink mission item.", example = "12", nullable = true)
+  private Integer lastMissionItemReachedSequence;
+
+  @Schema(description = "Timestamp when the most recent MAVLink mission item was reported reached.", example = "2026-07-30T03:05:00Z", nullable = true)
+  private Instant lastMissionItemReachedAt;
+
   @Schema(description = "Timestamp of the last operational state update.", example = "2026-04-20T05:42:00Z", nullable = true)
   private Instant operationalUpdatedAt;
 
@@ -192,7 +209,6 @@ public class DroneTwin extends EntityTwin {
   private double batteryCapacityHours;
 
   private StopActionEnum stopAction;
-
 
   public DroneTwin(String twinId) {
     this(twinId, null);

--- a/src/main/java/io/mapsmessaging/state/mavlink/listener/ListenerManager.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/listener/ListenerManager.java
@@ -22,7 +22,6 @@ package io.mapsmessaging.state.mavlink.listener;
 import io.mapsmessaging.state.drone.core.TwinManager;
 import io.mapsmessaging.state.drone.core.TwinUpdateContext;
 import io.mapsmessaging.state.mavlink.packet.MavlinkPacket;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -43,6 +42,7 @@ public class ListenerManager {
     listeners.put(HeartbeatListener.LISTENER_ID, new HeartbeatListener(twinManager));
     listeners.put(HomePositionListener.LISTENER_ID, new HomePositionListener(twinManager));
     listeners.put(MissionCurrentListener.LISTENER_ID, new MissionCurrentListener(twinManager));
+    listeners.put(MissionItemReachedListener.LISTENER_ID, new MissionItemReachedListener(twinManager));
     listeners.put(StatusTextListener.LISTENER_ID, new StatusTextListener(twinManager));
     listeners.put(SysStatusListener.LISTENER_ID, new SysStatusListener(twinManager));
     listeners.put(SystemTimeListener.LISTENER_ID, new SystemTimeListener(twinManager));

--- a/src/main/java/io/mapsmessaging/state/mavlink/listener/MissionItemReachedListener.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/listener/MissionItemReachedListener.java
@@ -1,0 +1,64 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.listener;
+
+import static io.mapsmessaging.state.mavlink.packet.MavlinkMessageIds.MISSION_ITEM_REACHED;
+
+import io.mapsmessaging.state.drone.core.TwinManager;
+import io.mapsmessaging.state.drone.core.TwinUpdateContext;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import io.mapsmessaging.state.mavlink.packet.MavlinkPacket;
+import io.mapsmessaging.state.mavlink.packet.MissionItemReachedPacket;
+import java.time.Instant;
+
+public class MissionItemReachedListener implements Listener {
+
+  public static final int LISTENER_ID = MISSION_ITEM_REACHED;
+
+  private final TwinManager twinManager;
+
+  public MissionItemReachedListener(TwinManager twinManager) {
+    this.twinManager = twinManager;
+  }
+
+  @Override
+  public void handle(String twinId, MavlinkPacket pkt, TwinUpdateContext context) {
+    if (!(pkt instanceof MissionItemReachedPacket packet) || !packet.isValid() || packet.getSequence() < 0) {
+      return;
+    }
+
+    Instant receivedAt =
+        context != null && context.getReceivedTime() != null
+            ? context.getReceivedTime()
+            : Instant.now();
+
+    twinManager.updateTwin(
+        twinId,
+        twin -> {
+          if (!(twin instanceof DroneTwin drone)) {
+            return;
+          }
+          drone.setLastMissionItemReachedSequence(packet.getSequence());
+          drone.setLastMissionItemReachedAt(receivedAt);
+          drone.setOperationalUpdatedAt(receivedAt);
+        },
+        context);
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/mavlink/packet/MavlinkMessageIds.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/packet/MavlinkMessageIds.java
@@ -29,6 +29,7 @@ public class MavlinkMessageIds {
   public static final int GLOBAL_POSITION_INT = 33;
   public static final int MISSION_REQUEST = 40;
   public static final int MISSION_CURRENT = 42;
+  public static final int MISSION_ITEM_REACHED = 46;
   public static final int MISSION_ACK = 47;
   public static final int MISSION_REQUEST_INT = 51;
   public static final int COMMAND_ACK = 77;
@@ -39,6 +40,7 @@ public class MavlinkMessageIds {
   public static final int EXTENDED_SYS_STATE = 245;
   public static final int NAMED_VALUE_FLOAT = 251;
   public static final int STATUSTEXT = 253;
+
   private MavlinkMessageIds() {
   }
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/packet/MavlinkPacketFactory.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/packet/MavlinkPacketFactory.java
@@ -24,7 +24,6 @@ import io.mapsmessaging.mavlink.ProcessedFrame;
 public class MavlinkPacketFactory {
 
   public static MavlinkPacket create(ProcessedFrame frame) {
-
     int messageId = frame.getFrame().getMessageId();
 
     return switch (messageId) {
@@ -40,6 +39,7 @@ public class MavlinkPacketFactory {
       case MavlinkMessageIds.HOME_POSITION -> new HomePositionPacket(frame);
       case MavlinkMessageIds.NAMED_VALUE_FLOAT -> new NamedValueFloatPacket(frame);
       case MavlinkMessageIds.MISSION_CURRENT -> new MissionCurrentPacket(frame);
+      case MavlinkMessageIds.MISSION_ITEM_REACHED -> new MissionItemReachedPacket(frame);
       case MavlinkMessageIds.MISSION_REQUEST -> new MissionRequestPacket(frame);
       case MavlinkMessageIds.MISSION_REQUEST_INT -> new MissionRequestIntPacket(frame);
       case MavlinkMessageIds.MISSION_ACK -> new MissionAckPacket(frame);

--- a/src/main/java/io/mapsmessaging/state/mavlink/packet/MissionItemReachedPacket.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/packet/MissionItemReachedPacket.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.packet;
+
+import static io.mapsmessaging.state.mavlink.packet.MavlinkMessageIds.MISSION_ITEM_REACHED;
+
+import io.mapsmessaging.mavlink.ProcessedFrame;
+import java.util.Map;
+
+public class MissionItemReachedPacket extends MavlinkPacket {
+
+  private final int sequence;
+  private final boolean valid;
+
+  public MissionItemReachedPacket(ProcessedFrame frame) {
+    Map<String, Object> fields = frame.getFields();
+    this.sequence = getInt(fields, "seq");
+    this.valid = frame.isValid();
+  }
+
+  public int getMessageId() {
+    return MISSION_ITEM_REACHED;
+  }
+
+  public boolean isValid() {
+    return valid;
+  }
+
+  public int getSequence() {
+    return sequence;
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/listener/MissionItemReachedListenerTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/listener/MissionItemReachedListenerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ */
+
+package io.mapsmessaging.state.mavlink.listener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.mapsmessaging.mavlink.ProcessedFrame;
+import io.mapsmessaging.state.drone.core.TwinManager;
+import io.mapsmessaging.state.drone.core.TwinUpdateContext;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import io.mapsmessaging.state.mavlink.packet.MavlinkMessageIds;
+import io.mapsmessaging.state.mavlink.packet.MissionItemReachedPacket;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MissionItemReachedListenerTest {
+
+  @Test
+  void handle_whenMissionItemIsReached_updatesDedicatedTwinState() {
+    TwinManager twinManager = new TwinManager();
+    DroneTwin droneTwin = new DroneTwin("mavlink:test:1");
+    twinManager.registerTwin(droneTwin, new TwinUpdateContext());
+
+    Instant receivedAt = Instant.parse("2026-07-30T03:05:00Z");
+    TwinUpdateContext context = new TwinUpdateContext();
+    context.setReceivedTime(receivedAt);
+
+    MissionItemReachedPacket packet = packet(0, true);
+    new MissionItemReachedListener(twinManager).handle("mavlink:test:1", packet, context);
+
+    DroneTwin updated = (DroneTwin) twinManager.getTwin("mavlink:test:1").orElseThrow();
+    assertEquals(MavlinkMessageIds.MISSION_ITEM_REACHED, packet.getMessageId());
+    assertEquals(0, updated.getLastMissionItemReachedSequence());
+    assertEquals(receivedAt, updated.getLastMissionItemReachedAt());
+    assertEquals(receivedAt, updated.getOperationalUpdatedAt());
+    assertNull(updated.getCurrentMissionSequence());
+  }
+
+  @Test
+  void handle_whenFrameIsInvalid_doesNotUpdateTwin() {
+    TwinManager twinManager = new TwinManager();
+    DroneTwin droneTwin = new DroneTwin("mavlink:test:1");
+    twinManager.registerTwin(droneTwin, new TwinUpdateContext());
+
+    TwinUpdateContext context = new TwinUpdateContext();
+    context.setReceivedTime(Instant.parse("2026-07-30T03:05:00Z"));
+
+    new MissionItemReachedListener(twinManager)
+        .handle("mavlink:test:1", packet(2, false), context);
+
+    DroneTwin updated = (DroneTwin) twinManager.getTwin("mavlink:test:1").orElseThrow();
+    assertNull(updated.getLastMissionItemReachedSequence());
+    assertNull(updated.getLastMissionItemReachedAt());
+  }
+
+  private MissionItemReachedPacket packet(int sequence, boolean valid) {
+    ProcessedFrame frame =
+        new ProcessedFrame(
+            "MISSION_ITEM_REACHED",
+            null,
+            Map.of("seq", sequence),
+            valid,
+            List.of(),
+            null);
+    return new MissionItemReachedPacket(frame);
+  }
+}


### PR DESCRIPTION
## Summary

- add MAVLink message id 46 (`MISSION_ITEM_REACHED`)
- decode the `seq` field into a typed `MissionItemReachedPacket`
- register a dedicated listener in the MAVLink twin update path
- store the most recently reached mission item sequence and received timestamp on `DroneTwin`
- keep `currentMissionSequence` separate from the reached-item state
- update `operationalUpdatedAt` when a reached event is received

## Tests

- valid reached events update the dedicated sequence and timestamp fields
- invalid frames do not update the twin
- the listener does not overwrite `currentMissionSequence`

## Related adapter change

- `Maps-Messaging/stanag-state-adapter#1` consumes fresh reached-item state to improve REPOSITION, point LOITER and navigation completion.

## Validation status

The branch is based on `development` and is 0 commits behind. The connected environment cannot run the private Maven/Buildkite dependency stack, so the change has source-level review and focused JUnit coverage but still requires the normal build before merge.