### PR TITLE
MAVLink area mission planning and repeated routes

### DIFF
--- a/.github/workflows/mavlink-area-mission-validation.yml
+++ b/.github/workflows/mavlink-area-mission-validation.yml
@@ -1,0 +1,25 @@
+name: MAVLink area mission validation
+
+on:
+  push:
+    branches:
+      - feature/mavlink-area-mission-planning
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run MAVLink mission tests
+        run: >-
+          mvn -B
+          -Dtest=MissionPlanRepeatTest,MavlinkCommandSetPreparerTest,MavlinkEventListSenderConcurrencyTest,SticklebackPassiveDetectionCapabilityTest
+          test

--- a/.github/workflows/mavlink-area-mission-validation.yml
+++ b/.github/workflows/mavlink-area-mission-validation.yml
@@ -18,6 +18,8 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
+      - name: Prepare test resources
+        run: mkdir -p src/test/resources
       - name: Run MAVLink mission tests
         run: >-
           mvn -B

--- a/.github/workflows/mavlink-area-mission-validation.yml
+++ b/.github/workflows/mavlink-area-mission-validation.yml
@@ -1,9 +1,9 @@
 name: MAVLink area mission validation
 
 on:
-  push:
+  pull_request:
     branches:
-      - feature/mavlink-area-mission-planning
+      - development
 
 permissions:
   contents: read

--- a/docs/review/mavlink-area-mission-planning.md
+++ b/docs/review/mavlink-area-mission-planning.md
@@ -1,0 +1,20 @@
+# MAVLink area mission planning
+
+This branch adds the MAVLink-side support required by the STANAG state adapter to execute ordered and continuously repeating area missions.
+
+## Changes
+
+- explicit finite and indefinite mission repetition through `MissionPlan`
+- `MAV_CMD_DO_JUMP` repeat-forever support using `param2=-1`
+- mission-plan navigation overload on `UxvModel`
+- canonical server-owned `MISSION_COUNT` framing and mission acknowledgement selection
+- validation of mission item type, target and sequence before upload
+- serialized inbound acknowledgement processing in `MavlinkEventListSender`
+- explicit passive detection capability on UxV models
+- Stickleback passive detection declaration while retaining fixed home-relative altitude policy
+
+## Validation
+
+Focused JUnit tests cover finite and indefinite repetition, mission framing, inbound acknowledgement serialization and Stickleback passive detection capability.
+
+A temporary branch-only GitHub Actions workflow is included solely to execute these tests. It will be removed after the validation result is captured.

--- a/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionItemIntFactory.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkMissionItemIntFactory.java
@@ -36,6 +36,7 @@ public final class MavlinkMissionItemIntFactory {
   public static final int MAV_CMD_DO_JUMP = 177;
 
   public static final int MAV_MISSION_TYPE_MISSION = 0;
+  public static final int MAV_CMD_DO_JUMP_REPEAT_FOREVER = -1;
 
   private static final float DEFAULT_WAYPOINT_ACCEPTANCE_RADIUS_METERS = 2.0f;
 
@@ -161,8 +162,8 @@ public final class MavlinkMissionItemIntFactory {
     if (targetMissionSequence < 0) {
       throw new IllegalArgumentException("targetMissionSequence must not be negative");
     }
-    if (repeatCount < 0) {
-      throw new IllegalArgumentException("repeatCount must not be negative");
+    if (repeatCount < MAV_CMD_DO_JUMP_REPEAT_FOREVER) {
+      throw new IllegalArgumentException("repeatCount must be -1 or greater");
     }
 
     MavlinkMissionItemInt missionItem = commandMissionItem(targetSystem, targetComponent, missionSequence, MAV_CMD_DO_JUMP);

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/MissionPlan.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/MissionPlan.java
@@ -22,20 +22,41 @@ package io.mapsmessaging.state.mavlink.model;
 import java.util.List;
 import java.util.Objects;
 
-public record MissionPlan(List<PlanItem> items, int iterations) {
+public record MissionPlan(List<PlanItem> items, int iterations, boolean repeatIndefinitely) {
 
-    public MissionPlan(List<PlanItem> items) {
-        this(items, 1);
+  public static final int REPEAT_FOREVER = -1;
+
+  public MissionPlan(List<PlanItem> items) {
+    this(items, 1, false);
+  }
+
+  public MissionPlan(List<PlanItem> items, int iterations) {
+    this(items, iterations, false);
+  }
+
+  public MissionPlan {
+    items = List.copyOf(Objects.requireNonNull(items, "items must not be null"));
+
+    if (items.isEmpty()) {
+      throw new IllegalArgumentException("items must not be empty");
     }
-
-    public MissionPlan {
-        items = List.copyOf(Objects.requireNonNull(items, "items must not be null"));
-
-        if (items.isEmpty()) {
-            throw new IllegalArgumentException("items must not be empty");
-        }
-        if (iterations < 1) {
-            throw new IllegalArgumentException("iterations must be at least 1");
-        }
+    if (iterations < 1) {
+      throw new IllegalArgumentException("iterations must be at least 1");
     }
+    if (repeatIndefinitely && iterations != 1) {
+      throw new IllegalArgumentException("An indefinitely repeating mission must use one logical iteration");
+    }
+  }
+
+  public static MissionPlan repeatIndefinitely(List<PlanItem> items) {
+    return new MissionPlan(items, 1, true);
+  }
+
+  public boolean repeats() {
+    return repeatIndefinitely || iterations > 1;
+  }
+
+  public int jumpRepeatCount() {
+    return repeatIndefinitely ? REPEAT_FOREVER : iterations - 1;
+  }
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
@@ -23,7 +23,6 @@ import io.mapsmessaging.state.drone.drone.DroneTwin;
 import io.mapsmessaging.state.drone.model.DetectionEvent;
 import io.mapsmessaging.state.drone.model.GeoPosition;
 import io.mapsmessaging.state.mavlink.packet.MavlinkPacket;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -32,91 +31,95 @@ import java.util.Set;
 
 public interface UxvModel {
 
-    String getModelName();
+  String getModelName();
 
-    UxvVehicleType getVehicleType();
+  UxvVehicleType getVehicleType();
 
-    Set<UxvOperation> getSupportedOperations();
+  Set<UxvOperation> getSupportedOperations();
 
-    default boolean supports(UxvOperation operation) {
-        return getSupportedOperations().contains(Objects.requireNonNull(operation, "operation must not be null"));
+  default boolean supports(UxvOperation operation) {
+    return getSupportedOperations().contains(Objects.requireNonNull(operation, "operation must not be null"));
+  }
+
+  default void requireSupported(UxvOperation operation) {
+    if (!supports(operation)) {
+      throw unsupported(operation);
     }
+  }
 
-    default void requireSupported(UxvOperation operation) {
-        if (!supports(operation)) {
-            throw unsupported(operation);
-        }
-    }
+  default Optional<DetectionEvent> interpretDetection(DroneTwin droneTwin, MavlinkPacket event) {
+    return Optional.empty();
+  }
 
-    default Optional<DetectionEvent> interpretDetection(DroneTwin droneTwin, MavlinkPacket event) {
-        return Optional.empty();
-    }
+  default UxvModelCommandSet arm(UxvCommandContext context) {
+    throw unsupported(UxvOperation.ARM);
+  }
 
-    default UxvModelCommandSet arm(UxvCommandContext context) {
-        throw unsupported(UxvOperation.ARM);
-    }
+  default UxvModelCommandSet disarm(UxvCommandContext context) {
+    throw unsupported(UxvOperation.DISARM);
+  }
 
-    default UxvModelCommandSet disarm(UxvCommandContext context) {
-        throw unsupported(UxvOperation.DISARM);
-    }
+  default UxvModelCommandSet setHome(UxvCommandContext context, HomeRequest request) {
+    throw unsupported(UxvOperation.SET_HOME);
+  }
 
-    default UxvModelCommandSet setHome(UxvCommandContext context, HomeRequest request) {
-        throw unsupported(UxvOperation.SET_HOME);
-    }
+  default UxvModelCommandSet returnToHome(UxvCommandContext context) {
+    throw unsupported(UxvOperation.RETURN_TO_HOME);
+  }
 
-    default UxvModelCommandSet returnToHome(UxvCommandContext context) {
-        throw unsupported(UxvOperation.RETURN_TO_HOME);
-    }
+  default UxvModelCommandSet reposition(UxvCommandContext context, RepositionRequest request) {
+    throw unsupported(UxvOperation.REPOSITION);
+  }
 
-    default UxvModelCommandSet reposition(UxvCommandContext context, RepositionRequest request) {
-        throw unsupported(UxvOperation.REPOSITION);
-    }
+  default UxvModelCommandSet orbit(UxvCommandContext context, OrbitRequest request) {
+    throw unsupported(UxvOperation.ORBIT);
+  }
 
-    default UxvModelCommandSet orbit(UxvCommandContext context, OrbitRequest request) {
-        throw unsupported(UxvOperation.ORBIT);
-    }
+  default UxvModelCommandSet loiter(UxvCommandContext context, LoiterRequest request) {
+    throw unsupported(UxvOperation.LOITER);
+  }
 
-    default UxvModelCommandSet loiter(UxvCommandContext context, LoiterRequest request) {
-        throw unsupported(UxvOperation.LOITER);
-    }
+  default UxvModelCommandSet holdPosition(UxvCommandContext context) {
+    throw unsupported(UxvOperation.HOLD_POSITION);
+  }
 
-    default UxvModelCommandSet holdPosition(UxvCommandContext context) {
-        throw unsupported(UxvOperation.HOLD_POSITION);
-    }
+  default UxvModelCommandSet stop(UxvCommandContext context) {
+    throw unsupported(UxvOperation.STOP);
+  }
 
-    default UxvModelCommandSet stop(UxvCommandContext context) {
-        throw unsupported(UxvOperation.STOP);
-    }
+  default UxvModelCommandSet pauseVehicle(UxvCommandContext context) {
+    throw unsupported(UxvOperation.PAUSE_VEHICLE);
+  }
 
-    default UxvModelCommandSet pauseVehicle(UxvCommandContext context) {
-        throw unsupported(UxvOperation.PAUSE_VEHICLE);
-    }
+  default UxvModelCommandSet resumeVehicle(UxvCommandContext context) {
+    throw unsupported(UxvOperation.RESUME_VEHICLE);
+  }
 
-    default UxvModelCommandSet resumeVehicle(UxvCommandContext context) {
-        throw unsupported(UxvOperation.RESUME_VEHICLE);
-    }
+  default PlanValidation validateMission(MissionPlan missionPlan) {
+    return PlanValidation.success();
+  }
 
-    default PlanValidation validateMission(MissionPlan missionPlan) {
-        return PlanValidation.success();
-    }
+  default UxvModelCommandSet buildMission(UxvCommandContext context, MissionPlan missionPlan) {
+    throw unsupported(UxvOperation.BUILD_MISSION);
+  }
 
-    default UxvModelCommandSet buildMission(UxvCommandContext context, MissionPlan missionPlan) {
-        throw unsupported(UxvOperation.BUILD_MISSION);
-    }
+  default UxvModelCommandSet startMission(UxvCommandContext context) {
+    throw unsupported(UxvOperation.START_MISSION);
+  }
 
-    default UxvModelCommandSet startMission(UxvCommandContext context) {
-        throw unsupported(UxvOperation.START_MISSION);
-    }
+  default UxvModelCommandSet clearMission(UxvCommandContext context) {
+    throw unsupported(UxvOperation.CLEAR_MISSION);
+  }
 
-    default UxvModelCommandSet clearMission(UxvCommandContext context) {
-        throw unsupported(UxvOperation.CLEAR_MISSION);
-    }
+  default UxvNavigationPlan navigate(UxvCommandContext context, List<GeoPosition> waypoints, Duration duration) {
+    throw unsupported(UxvOperation.NAVIGATE);
+  }
 
-    default UxvNavigationPlan navigate(UxvCommandContext context, List<GeoPosition> waypoints, Duration duration) {
-        throw unsupported(UxvOperation.NAVIGATE);
-    }
+  default UxvNavigationPlan navigate(UxvCommandContext context, MissionPlan missionPlan, Duration duration) {
+    throw unsupported(UxvOperation.NAVIGATE);
+  }
 
-    default UnsupportedUxvOperationException unsupported(UxvOperation operation) {
-        return new UnsupportedUxvOperationException(getModelName(), operation);
-    }
+  default UnsupportedUxvOperationException unsupported(UxvOperation operation) {
+    return new UnsupportedUxvOperationException(getModelName(), operation);
+  }
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
@@ -119,7 +119,7 @@ public interface UxvModel {
     throw unsupported(UxvOperation.NAVIGATE);
   }
 
-  default UxvNavigationPlan navigate(UxvCommandContext context, MissionPlan missionPlan, Duration duration) {
+  default UxvNavigationPlan navigatePlan(UxvCommandContext context, MissionPlan missionPlan, Duration duration) {
     throw unsupported(UxvOperation.NAVIGATE);
   }
 

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
@@ -47,6 +47,10 @@ public interface UxvModel {
     }
   }
 
+  default boolean supportsPassiveDetection() {
+    return false;
+  }
+
   default Optional<DetectionEvent> interpretDetection(DroneTwin droneTwin, MavlinkPacket event) {
     return Optional.empty();
   }

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/impl/AbstractMissionUxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/impl/AbstractMissionUxvModel.java
@@ -68,11 +68,11 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
       GeoPosition position = Objects.requireNonNull(waypoints.get(index), "waypoints[" + index + "] must not be null");
       items.add(new PlanItem(PlanItemType.WAYPOINT, position, null, null, null, null, null, null));
     }
-    return navigate(context, new MissionPlan(items), duration);
+    return navigatePlan(context, new MissionPlan(items), duration);
   }
 
   @Override
-  public final UxvNavigationPlan navigate(UxvCommandContext context, MissionPlan missionPlan, Duration duration) {
+  public final UxvNavigationPlan navigatePlan(UxvCommandContext context, MissionPlan missionPlan, Duration duration) {
     Objects.requireNonNull(context, "context must not be null");
     Objects.requireNonNull(missionPlan, "missionPlan must not be null");
 

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/impl/AbstractMissionUxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/impl/AbstractMissionUxvModel.java
@@ -61,7 +61,6 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
 
   @Override
   public final UxvNavigationPlan navigate(UxvCommandContext context, List<GeoPosition> waypoints, Duration duration) {
-    Objects.requireNonNull(context, "context must not be null");
     Objects.requireNonNull(waypoints, "waypoints must not be null");
 
     List<PlanItem> items = new ArrayList<>(waypoints.size());
@@ -69,8 +68,14 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
       GeoPosition position = Objects.requireNonNull(waypoints.get(index), "waypoints[" + index + "] must not be null");
       items.add(new PlanItem(PlanItemType.WAYPOINT, position, null, null, null, null, null, null));
     }
+    return navigate(context, new MissionPlan(items), duration);
+  }
 
-    MissionPlan missionPlan = new MissionPlan(items);
+  @Override
+  public final UxvNavigationPlan navigate(UxvCommandContext context, MissionPlan missionPlan, Duration duration) {
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(missionPlan, "missionPlan must not be null");
+
     return new UxvNavigationPlan(
         List.of(buildMission(context, missionPlan)),
         List.of(startMission(context)),
@@ -114,10 +119,9 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
 
     GeoPosition position = Objects.requireNonNull(request.position(), "position must not be null");
     List<MavlinkMessage> messages = List.of(
-            MavlinkCommandIntFactory.reposition(context.targetSystem(), context.targetComponent(), position, context.sequence()),
-            MavlinkCommandLongFactory.guidedMode(context.targetSystem(), context.targetComponent(), context.sequence()),
-            MavlinkMissionItemFactory.guidedWaypoint(context.targetSystem(), context.targetComponent(), position)
-        );
+        MavlinkCommandIntFactory.reposition(context.targetSystem(), context.targetComponent(), position, context.sequence()),
+        MavlinkCommandLongFactory.guidedMode(context.targetSystem(), context.targetComponent(), context.sequence()),
+        MavlinkMissionItemFactory.guidedWaypoint(context.targetSystem(), context.targetComponent(), position));
     return UxvModelCommandSet.of(UxvOperation.REPOSITION, getModelName(), messages);
   }
 
@@ -128,7 +132,7 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
 
   @Override
   public UxvModelCommandSet stop(UxvCommandContext context) {
-    java.util.Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(context, "context must not be null");
     MavlinkMessage message = MavlinkCommandIntFactory.stop(context.targetSystem(), context.targetComponent(), context.sequence());
     return UxvModelCommandSet.of(UxvOperation.STOP, getModelName(), message);
   }
@@ -156,12 +160,9 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
       validatePlanItem(index, item, issues);
     }
 
-    if (missionPlan.iterations() > 1
+    if (missionPlan.repeats()
         && missionPlan.items().stream().anyMatch(item -> item.type() == PlanItemType.RETURN_TO_HOME)) {
-      issues.add(
-          new PlanValidationIssue(
-              UxvOperation.BUILD_MISSION,
-              "A repeating mission must not contain RETURN_TO_HOME"));
+      issues.add(new PlanValidationIssue(UxvOperation.BUILD_MISSION, "A repeating mission must not contain RETURN_TO_HOME"));
     }
 
     return issues.isEmpty() ? PlanValidation.success() : PlanValidation.failure(issues);
@@ -176,22 +177,21 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
       throw new IllegalArgumentException("Invalid mission plan: " + validation.issues());
     }
 
-    int additionalItems = missionPlan.iterations() > 1 ? 1 : 0;
-    List<MavlinkMessage> messages =
-        new ArrayList<>(missionPlan.items().size() + additionalItems);
+    int additionalItems = missionPlan.repeats() ? 1 : 0;
+    List<MavlinkMessage> messages = new ArrayList<>(missionPlan.items().size() + additionalItems);
 
     for (int index = 0; index < missionPlan.items().size(); index++) {
       messages.add(toMissionMessage(context, index, missionPlan.items().get(index)));
     }
 
-    if (missionPlan.iterations() > 1) {
+    if (missionPlan.repeats()) {
       messages.add(
           MavlinkMissionItemIntFactory.jump(
               context.targetSystem(),
               context.targetComponent(),
               missionPlan.items().size(),
               0,
-              missionPlan.iterations() - 1));
+              missionPlan.jumpRepeatCount()));
     }
 
     return UxvModelCommandSet.of(UxvOperation.BUILD_MISSION, getModelName(), messages);
@@ -238,7 +238,6 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
 
     return UxvModelCommandSet.of(UxvOperation.SET_HEADING, getModelName(), commandLong);
   }
-
 
   private void validateCommonPlanItem(int index, PlanItem item, List<PlanValidationIssue> issues) {
     String itemName = "Mission item " + index;
@@ -453,5 +452,4 @@ public abstract class AbstractMissionUxvModel extends AbstractUxvModel {
     }
     return normalised;
   }
-
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/impl/usv/SticklebackArdupilotUsvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/impl/usv/SticklebackArdupilotUsvModel.java
@@ -230,6 +230,11 @@ public class SticklebackArdupilotUsvModel extends GenericArduPilotUxvModel imple
   }
 
   @Override
+  public boolean supportsPassiveDetection() {
+    return true;
+  }
+
+  @Override
   public Optional<DetectionEvent> interpretDetection(DroneTwin droneTwin, MavlinkPacket event) {
     if (!(event instanceof NamedValueFloatPacket packet)) {
       return Optional.empty();

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkCommandSetPreparer.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkCommandSetPreparer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.sender;
+
+import io.mapsmessaging.state.mavlink.messages.MavlinkMessage;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionCount;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionCountFactory;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemInt;
+import io.mapsmessaging.state.mavlink.model.UxvModelCommandSet;
+import io.mapsmessaging.state.mavlink.model.UxvOperation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class MavlinkCommandSetPreparer {
+
+  private MavlinkCommandSetPreparer() {
+  }
+
+  public static PreparedMavlinkCommandSet prepare(UxvModelCommandSet commandSet) {
+    Objects.requireNonNull(commandSet, "commandSet must not be null");
+    if (commandSet.operation() != UxvOperation.BUILD_MISSION) {
+      return new PreparedMavlinkCommandSet(commandSet, new MavlinkCommandAcknowledgementHandler());
+    }
+    return prepareMission(commandSet);
+  }
+
+  private static PreparedMavlinkCommandSet prepareMission(UxvModelCommandSet commandSet) {
+    List<MavlinkMessage> messages = commandSet.messages();
+    if (messages.isEmpty()) {
+      throw new IllegalArgumentException("Mission command set contains no messages");
+    }
+
+    List<MavlinkMessage> uploadMessages;
+    int itemCount;
+    if (messages.get(0) instanceof MavlinkMissionCount missionCount) {
+      itemCount = missionCount.getCount();
+      if (itemCount != messages.size() - 1) {
+        throw new IllegalArgumentException("MISSION_COUNT does not match the number of mission items");
+      }
+      validateMissionItems(messages.subList(1, messages.size()), missionCount.getTargetSystem(), missionCount.getTargetComponent());
+      uploadMessages = List.copyOf(messages);
+    } else {
+      MavlinkMissionItemInt firstItem = requireMissionItem(messages.get(0), 0);
+      validateMissionItems(messages, firstItem.getTargetSystem(), firstItem.getTargetComponent());
+      itemCount = messages.size();
+      uploadMessages = new ArrayList<>(itemCount + 1);
+      uploadMessages.add(MavlinkMissionCountFactory.mission(firstItem.getTargetSystem(), firstItem.getTargetComponent(), itemCount));
+      uploadMessages.addAll(messages);
+      uploadMessages = List.copyOf(uploadMessages);
+    }
+
+    UxvModelCommandSet prepared = UxvModelCommandSet.of(commandSet.operation(), commandSet.modelName(), uploadMessages);
+    return new PreparedMavlinkCommandSet(prepared, new MavlinkMissionAcknowledgementHandler(uploadMessages, itemCount));
+  }
+
+  private static void validateMissionItems(List<MavlinkMessage> messages, int targetSystem, int targetComponent) {
+    for (int index = 0; index < messages.size(); index++) {
+      MavlinkMissionItemInt item = requireMissionItem(messages.get(index), index);
+      if (item.getTargetSystem() != targetSystem || item.getTargetComponent() != targetComponent) {
+        throw new IllegalArgumentException("Mission item " + index + " targets a different vehicle or component");
+      }
+      if (item.getMissionSequence() != index) {
+        throw new IllegalArgumentException("Mission item " + index + " has sequence " + item.getMissionSequence());
+      }
+    }
+  }
+
+  private static MavlinkMissionItemInt requireMissionItem(MavlinkMessage message, int index) {
+    if (!(message instanceof MavlinkMissionItemInt missionItem)) {
+      throw new IllegalArgumentException("Mission message " + index + " is not MISSION_ITEM_INT");
+    }
+    return missionItem;
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
@@ -46,6 +46,7 @@ public class MavlinkEventListSender implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(MavlinkEventListSender.class);
 
   private final Object lock;
+  private final Object inboundLock;
   private final UUID sequenceId;
   private final UxvModelCommandSet commandSet;
   private final List<MavlinkMessage> messages;
@@ -93,6 +94,7 @@ public class MavlinkEventListSender implements AutoCloseable {
     }
 
     this.lock = new Object();
+    this.inboundLock = new Object();
     this.sequenceId = UUID.randomUUID();
     this.commandSet = Objects.requireNonNull(commandSet, "commandSet must not be null");
     this.messages = List.copyOf(Objects.requireNonNull(commandSet.messages(), "commandSet.messages must not be null"));
@@ -130,30 +132,30 @@ public class MavlinkEventListSender implements AutoCloseable {
 
     Objects.requireNonNull(receivedPacket, "receivedMessage must not be null");
 
-    MavlinkMessage sentMessage;
-    int sentIndex;
+    synchronized (inboundLock) {
+      MavlinkMessage sentMessage;
+      int sentIndex;
 
-    synchronized (lock) {
-      if (terminal) {
-        logger.log(MAVLINK_EVENT_LIST_SENDER_INBOUND_IGNORED_TERMINAL, sequenceId, commandSet.operation(), commandSet.modelName());
-        return;
+      synchronized (lock) {
+        if (terminal) {
+          logger.log(MAVLINK_EVENT_LIST_SENDER_INBOUND_IGNORED_TERMINAL, sequenceId, commandSet.operation(), commandSet.modelName());
+          return;
+        }
+        if (waitingMessage == null) {
+          logger.log(MAVLINK_EVENT_LIST_SENDER_INBOUND_IGNORED_NOT_WAITING, sequenceId, commandSet.operation(), commandSet.modelName());
+          return;
+        }
+
+        sentMessage = waitingMessage;
+        sentIndex = waitingIndex;
       }
-      if (waitingMessage == null) {
-        logger.log(MAVLINK_EVENT_LIST_SENDER_INBOUND_IGNORED_NOT_WAITING, sequenceId, commandSet.operation(), commandSet.modelName());
-        return;
+
+      Acknowledgement acknowledgement = acknowledgementHandler.acknowledge(sentMessage, receivedPacket);
+      if (acknowledgement == null) {
+        acknowledgement = Acknowledgement.notRelated();
       }
-
-      sentMessage = waitingMessage;
-      sentIndex = waitingIndex;
+      handleAcknowledgement(sentMessage, receivedPacket, sentIndex, acknowledgement);
     }
-
-    Acknowledgement acknowledgement = acknowledgementHandler.acknowledge(sentMessage, receivedPacket);
-
-    if (acknowledgement == null) {
-      acknowledgement = Acknowledgement.notRelated();
-    }
-
-    handleAcknowledgement(sentMessage, receivedPacket, sentIndex, acknowledgement);
   }
 
   public void timeout() {
@@ -251,7 +253,6 @@ public class MavlinkEventListSender implements AutoCloseable {
     }
 
     logger.log(MAVLINK_EVENT_LIST_SENDER_ACK_SUCCESS, sequenceId, commandSet.operation(), commandSet.modelName(), sentIndex + 1);
-
     walk();
   }
 
@@ -295,7 +296,6 @@ public class MavlinkEventListSender implements AutoCloseable {
         nextIndex++;
 
         requiresAcknowledgement = acknowledgementHandler.requiresAcknowledgement(message);
-
         if (requiresAcknowledgement) {
           prepareWaitingState(sentIndex, message);
         }
@@ -343,7 +343,6 @@ public class MavlinkEventListSender implements AutoCloseable {
     }
 
     logger.log(MAVLINK_EVENT_LIST_SENDER_NO_ACK_ADVANCING, sequenceId, commandSet.operation(), commandSet.modelName(), requestedIndex + 1);
-
     walk();
   }
 
@@ -399,7 +398,6 @@ public class MavlinkEventListSender implements AutoCloseable {
                   () -> processTimeout(index, message, generation),
                   acknowledgementTimeoutMillis,
                   TimeUnit.MILLISECONDS);
-
     }
   }
 
@@ -444,7 +442,6 @@ public class MavlinkEventListSender implements AutoCloseable {
 
       terminal = true;
       clearWaitingState();
-
       result = new MavlinkSendResult(this, sequenceId, status, index, messages.size(), sentMessage, receivedMessage, cause, reason);
     }
 
@@ -507,13 +504,10 @@ public class MavlinkEventListSender implements AutoCloseable {
     if (acknowledgement.reason() == null || acknowledgement.reason().isBlank()) {
       return "MAVLink acknowledgement failed";
     }
-
     return acknowledgement.reason();
   }
 
   private String messageName(MavlinkMessage message) {
-    return message == null
-        ? ""
-        : message.getClass().getSimpleName();
+    return message == null ? "" : message.getClass().getSimpleName();
   }
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/PreparedMavlinkCommandSet.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/PreparedMavlinkCommandSet.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.sender;
+
+import io.mapsmessaging.state.mavlink.model.UxvModelCommandSet;
+import java.util.Objects;
+
+public record PreparedMavlinkCommandSet(
+    UxvModelCommandSet commandSet,
+    MavlinkAcknowledgementHandler acknowledgementHandler) {
+
+  public PreparedMavlinkCommandSet {
+    commandSet = Objects.requireNonNull(commandSet, "commandSet must not be null");
+    acknowledgementHandler = Objects.requireNonNull(acknowledgementHandler, "acknowledgementHandler must not be null");
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/model/MissionPlanRepeatTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/model/MissionPlanRepeatTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.mapsmessaging.state.drone.model.GeoPosition;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemInt;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemIntFactory;
+import io.mapsmessaging.state.mavlink.model.impl.uav.GenericPx4UavModel;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class MissionPlanRepeatTest {
+
+  private static final UxvCommandContext CONTEXT = new UxvCommandContext(UUID.randomUUID(), 10, 1, 255, 190, 7);
+  private static final PlanItem WAYPOINT = new PlanItem(PlanItemType.WAYPOINT, new GeoPosition(59.4673d, 24.828353d, 25.0d, null), null, null, null, null, null, null);
+
+  @Test
+  void repeatIndefinitelyAddsForeverJump() {
+    GenericPx4UavModel model = new GenericPx4UavModel();
+    MissionPlan plan = MissionPlan.repeatIndefinitely(List.of(WAYPOINT));
+
+    UxvModelCommandSet commandSet = model.buildMission(CONTEXT, plan);
+
+    assertTrue(plan.repeats());
+    assertTrue(plan.repeatIndefinitely());
+    assertEquals(2, commandSet.messages().size());
+    MavlinkMissionItemInt jump = (MavlinkMissionItemInt) commandSet.messages().get(1);
+    assertEquals(MavlinkMissionItemIntFactory.MAV_CMD_DO_JUMP, jump.getCommand());
+    assertEquals(0.0f, jump.getParam1());
+    assertEquals(MavlinkMissionItemIntFactory.MAV_CMD_DO_JUMP_REPEAT_FOREVER, (int) jump.getParam2());
+  }
+
+  @Test
+  void finiteIterationsAddFiniteJumpCount() {
+    GenericPx4UavModel model = new GenericPx4UavModel();
+    MissionPlan plan = new MissionPlan(List.of(WAYPOINT), 3);
+
+    UxvModelCommandSet commandSet = model.buildMission(CONTEXT, plan);
+
+    assertTrue(plan.repeats());
+    assertFalse(plan.repeatIndefinitely());
+    MavlinkMissionItemInt jump = (MavlinkMissionItemInt) commandSet.messages().get(1);
+    assertEquals(2.0f, jump.getParam2());
+  }
+
+  @Test
+  void oneShotMissionDoesNotAddJump() {
+    GenericPx4UavModel model = new GenericPx4UavModel();
+
+    UxvModelCommandSet commandSet = model.buildMission(CONTEXT, new MissionPlan(List.of(WAYPOINT)));
+
+    assertEquals(1, commandSet.messages().size());
+  }
+
+  @Test
+  void repeatingMissionRejectsReturnToHome() {
+    GenericPx4UavModel model = new GenericPx4UavModel();
+    PlanItem returnToHome = new PlanItem(PlanItemType.RETURN_TO_HOME, null, null, null, null, null, null, null);
+
+    assertThrows(IllegalArgumentException.class, () -> model.buildMission(CONTEXT, MissionPlan.repeatIndefinitely(List.of(returnToHome))));
+  }
+
+  @Test
+  void jumpRejectsValuesBelowRepeatForever() {
+    assertThrows(IllegalArgumentException.class, () -> MavlinkMissionItemIntFactory.jump(10, 1, 1, 0, -2));
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/model/impl/usv/SticklebackPassiveDetectionCapabilityTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/model/impl/usv/SticklebackPassiveDetectionCapabilityTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.model.impl.usv;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.mapsmessaging.state.mavlink.model.impl.uav.GenericPx4UavModel;
+import org.junit.jupiter.api.Test;
+
+class SticklebackPassiveDetectionCapabilityTest {
+
+  @Test
+  void sticklebackDeclaresPassiveDetectionSupport() {
+    assertTrue(new SticklebackArdupilotUsvModel().supportsPassiveDetection());
+  }
+
+  @Test
+  void genericModelsDoNotDeclarePassiveDetectionSupport() {
+    assertFalse(new GenericPx4UavModel().supportsPassiveDetection());
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkCommandSetPreparerTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkCommandSetPreparerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.sender;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.mapsmessaging.state.drone.model.GeoPosition;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionCount;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionCountFactory;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemInt;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemIntFactory;
+import io.mapsmessaging.state.mavlink.model.UxvModelCommandSet;
+import io.mapsmessaging.state.mavlink.model.UxvOperation;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MavlinkCommandSetPreparerTest {
+
+  @Test
+  void prepareMissionPrependsCanonicalMissionCount() {
+    MavlinkMissionItemInt first = waypoint(0, 59.4673d, 24.828353d);
+    MavlinkMissionItemInt second = waypoint(1, 59.4680d, 24.8290d);
+    UxvModelCommandSet commandSet = UxvModelCommandSet.of(UxvOperation.BUILD_MISSION, "test-model", List.of(first, second));
+
+    PreparedMavlinkCommandSet prepared = MavlinkCommandSetPreparer.prepare(commandSet);
+
+    assertEquals(3, prepared.commandSet().messages().size());
+    MavlinkMissionCount count = assertInstanceOf(MavlinkMissionCount.class, prepared.commandSet().messages().get(0));
+    assertEquals(10, count.getTargetSystem());
+    assertEquals(1, count.getTargetComponent());
+    assertEquals(2, count.getCount());
+    assertSame(first, prepared.commandSet().messages().get(1));
+    assertSame(second, prepared.commandSet().messages().get(2));
+    assertInstanceOf(MavlinkMissionAcknowledgementHandler.class, prepared.acknowledgementHandler());
+  }
+
+  @Test
+  void prepareMissionAcceptsAlreadyFramedMission() {
+    MavlinkMissionCount count = MavlinkMissionCountFactory.mission(10, 1, 1);
+    MavlinkMissionItemInt item = waypoint(0, 59.4673d, 24.828353d);
+    UxvModelCommandSet commandSet = UxvModelCommandSet.of(UxvOperation.BUILD_MISSION, "test-model", List.of(count, item));
+
+    PreparedMavlinkCommandSet prepared = MavlinkCommandSetPreparer.prepare(commandSet);
+
+    assertSame(count, prepared.commandSet().messages().get(0));
+    assertSame(item, prepared.commandSet().messages().get(1));
+  }
+
+  @Test
+  void prepareMissionRejectsSequenceGaps() {
+    MavlinkMissionItemInt item = waypoint(1, 59.4673d, 24.828353d);
+    UxvModelCommandSet commandSet = UxvModelCommandSet.of(UxvOperation.BUILD_MISSION, "test-model", List.of(item));
+
+    assertThrows(IllegalArgumentException.class, () -> MavlinkCommandSetPreparer.prepare(commandSet));
+  }
+
+  @Test
+  void prepareCommandUsesCommandAcknowledgementHandler() {
+    UxvModelCommandSet commandSet = UxvModelCommandSet.empty(UxvOperation.STOP, "test-model");
+
+    PreparedMavlinkCommandSet prepared = MavlinkCommandSetPreparer.prepare(commandSet);
+
+    assertSame(commandSet, prepared.commandSet());
+    assertInstanceOf(MavlinkCommandAcknowledgementHandler.class, prepared.acknowledgementHandler());
+  }
+
+  private MavlinkMissionItemInt waypoint(int sequence, double latitude, double longitude) {
+    return MavlinkMissionItemIntFactory.waypoint(10, 1, sequence, new GeoPosition(latitude, longitude, 20.0d, null));
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderConcurrencyTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderConcurrencyTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.sender;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import io.mapsmessaging.state.mavlink.messages.MavlinkMessage;
+import io.mapsmessaging.state.mavlink.model.UxvModelCommandSet;
+import io.mapsmessaging.state.mavlink.model.UxvOperation;
+import io.mapsmessaging.state.mavlink.packet.MavlinkPacket;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class MavlinkEventListSenderConcurrencyTest {
+
+  @Test
+  void concurrentInboundPacketsAreProcessedSerially() throws Exception {
+    MavlinkMessage message = mock(MavlinkMessage.class);
+    AtomicInteger activeCalls = new AtomicInteger();
+    AtomicInteger maximumActiveCalls = new AtomicInteger();
+    CountDownLatch firstEntered = new CountDownLatch(1);
+    CountDownLatch releaseFirst = new CountDownLatch(1);
+
+    MavlinkAcknowledgementHandler handler = new MavlinkAcknowledgementHandler() {
+      @Override
+      public boolean requiresAcknowledgement(MavlinkMessage sentMessage) {
+        return true;
+      }
+
+      @Override
+      public Acknowledgement acknowledge(MavlinkMessage sentMessage, MavlinkPacket receivedMessage) {
+        int active = activeCalls.incrementAndGet();
+        maximumActiveCalls.accumulateAndGet(active, Math::max);
+        firstEntered.countDown();
+        try {
+          assertTrue(releaseFirst.await(Duration.ofSeconds(2).toMillis(), TimeUnit.MILLISECONDS));
+          return Acknowledgement.notRelated();
+        } catch (InterruptedException exception) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError(exception);
+        } finally {
+          activeCalls.decrementAndGet();
+        }
+      }
+    };
+
+    MavlinkEventListSender sender =
+        new MavlinkEventListSender(
+            UxvModelCommandSet.of(UxvOperation.BUILD_MISSION, "test-model", List.of(message)),
+            ignored -> {},
+            handler,
+            ignored -> {},
+            0,
+            10_000L);
+    sender.start();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> first = executor.submit(() -> sender.onMavlinkMessage(mock(MavlinkPacket.class)));
+      assertTrue(firstEntered.await(2, TimeUnit.SECONDS));
+      Future<?> second = executor.submit(() -> sender.onMavlinkMessage(mock(MavlinkPacket.class)));
+
+      Thread.sleep(50L);
+      assertEquals(1, maximumActiveCalls.get());
+
+      releaseFirst.countDown();
+      first.get(2, TimeUnit.SECONDS);
+      second.get(2, TimeUnit.SECONDS);
+      assertEquals(1, maximumActiveCalls.get());
+    } finally {
+      releaseFirst.countDown();
+      sender.cancel();
+      executor.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add explicit finite and indefinite mission repetition
- generate `MAV_CMD_DO_JUMP` repeat-forever missions
- expose mission-plan navigation through `UxvModel`
- centralise `MISSION_COUNT` framing and mission acknowledgement handling in the server
- validate mission item type, target and sequence before upload
- serialize inbound acknowledgement processing to protect requested-index mission uploads
- declare passive detection capability explicitly and enable it for Stickleback
- retain Stickleback's fixed home-relative control altitude for all direct and mission commands

## Adapter dependency

The coordinated `stanag-state-adapter` feature branch consumes the new mission-plan overload, command-set preparer and passive-detection capability.

## Validation

Focused tests cover mission repetition, canonical upload framing, acknowledgement concurrency and passive detection capability. A temporary branch-only workflow is included to run these tests and will be removed after validation.
