### PR TITLE
Add ArduPilot mission sequencing and survey radius

### DIFF
--- a/src/main/java/io/mapsmessaging/state/config/DroneInfoDTO.java
+++ b/src/main/java/io/mapsmessaging/state/config/DroneInfoDTO.java
@@ -21,52 +21,45 @@ package io.mapsmessaging.state.config;
 
 import io.mapsmessaging.state.config.capability.TaskCapabilities;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.Map;
 import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Setter
 public class DroneInfoDTO {
 
-  @Schema(
-      description = "Unique drone id"
-  )
+  @Schema(description = "Unique drone id")
   private String name;
 
-  @Schema(
-      description = "UUID of drone"
-  )
+  @Schema(description = "UUID of drone")
   private UUID uuid;
 
-  @Schema(
-      description = "Configured UxV model name used to resolve the command model implementation."
-  )
+  @Schema(description = "Configured UxV model name used to resolve the command model implementation.")
   private String modelName;
 
   @Schema(description = "Message encoding used when communicating with this drone.")
   private MessageEncodingEnum messageEncoding = MessageEncodingEnum.JSON;
 
-  @Schema(
-      description = "Total battery capacity in amp-hours."
-  )
+  @Schema(description = "Total battery capacity in amp-hours.")
   private double batteryCapacityAh = 0.0;
 
-  @Schema(
-      description = "Total battery capacity in hours."
-  )
+  @Schema(description = "Total battery capacity in hours.")
   private double batteryCapacityHours = 0.0;
 
   @Schema(
-      description = "Drone description"
-  )
+      description =
+          "Survey coverage radius in metres measured from the vehicle centreline. "
+              + "The effective survey width is twice this value.",
+      example = "200.0",
+      nullable = true)
+  private Double surveyRadiusMeters;
+
+  @Schema(description = "Drone description")
   private Map<String, Object> description;
 
-  @Schema(
-      description = "Task capabilities supported by this known MAVLink source."
-  )
+  @Schema(description = "Task capabilities supported by this known MAVLink source.")
   private TaskCapabilities capabilities = new TaskCapabilities();
 
   @Schema(description = "Action performed when the current task is cancelled.")

--- a/src/main/java/io/mapsmessaging/state/config/TwinManagerConfig.java
+++ b/src/main/java/io/mapsmessaging/state/config/TwinManagerConfig.java
@@ -360,25 +360,13 @@ public class TwinManagerConfig extends TwinManagerConfigDTO implements Config, C
     droneInfo.setBatteryCapacityHours(properties.getDoubleProperty("batteryCapacityHours", droneInfo.getBatteryCapacityHours()));
     droneInfo.setName(properties.getProperty("name", droneInfo.getName()));
     droneInfo.setModelName(properties.getProperty("modelName", droneInfo.getModelName()));
-    droneInfo.setMessageEncoding(
-        parseMessageEncoding(
-            properties.getProperty("messageEncoding", null),
-            droneInfo.getMessageEncoding()));
-
-    StopActionEnum legacyStopAction =
-        parseTerminalAction(
-            properties.getProperty("stopAction", null),
-            droneInfo.getCancelAction());
-
-    droneInfo.setCancelAction(
-        parseTerminalAction(
-            properties.getProperty("cancelAction", null),
-            legacyStopAction));
-
-    droneInfo.setMissionEndAction(
-        parseTerminalAction(
-            properties.getProperty("missionEndAction", null),
-            droneInfo.getMissionEndAction()));
+    if(properties.containsKey("surveyRadiusMeters") && properties.getDoubleProperty("surveyRadiusMeters", 0.0) > 0.0) {
+      droneInfo.setSurveyRadiusMeters(properties.getDoubleProperty("surveyRadiusMeters", 0.0));
+    }
+    droneInfo.setMessageEncoding(parseMessageEncoding(properties.getProperty("messageEncoding", null), droneInfo.getMessageEncoding()));
+    StopActionEnum legacyStopAction = parseTerminalAction(properties.getProperty("stopAction", null), droneInfo.getCancelAction());
+    droneInfo.setCancelAction(parseTerminalAction(properties.getProperty("cancelAction", null), legacyStopAction));
+    droneInfo.setMissionEndAction(parseTerminalAction(properties.getProperty("missionEndAction", null), droneInfo.getMissionEndAction()));
 
     droneInfo.setMissionTimeoutAction(
         parseTerminalAction(

--- a/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
+++ b/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
@@ -208,6 +208,14 @@ public class DroneTwin extends EntityTwin {
   @Schema(description = "Battery capacity in hours", example = "48", nullable = true)
   private double batteryCapacityHours;
 
+  @Schema(
+      description =
+          "Survey coverage radius in metres measured from the vehicle centreline. "
+              + "The effective survey width is twice this value.",
+      example = "200.0",
+      nullable = true)
+  private Double surveyRadiusMeters;
+
   private StopActionEnum stopAction;
 
   public DroneTwin(String twinId) {

--- a/src/main/java/io/mapsmessaging/state/mavlink/MavlinkTwinUpdater.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/MavlinkTwinUpdater.java
@@ -19,6 +19,8 @@
 
 package io.mapsmessaging.state.mavlink;
 
+import static io.mapsmessaging.state.logging.StateLogMessages.MAVLINK_STATE_TWIN_CREATED;
+
 import io.mapsmessaging.dto.rest.config.protocol.impl.MavlinkKnownSourceDTO;
 import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
@@ -42,12 +44,9 @@ import io.mapsmessaging.state.mavlink.model.ModelManager;
 import io.mapsmessaging.state.mavlink.model.UxvModel;
 import io.mapsmessaging.state.mavlink.packet.MavlinkPacket;
 import io.mapsmessaging.state.mavlink.sender.MavlinkEventListSender;
+import java.util.Optional;
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Optional;
-
-import static io.mapsmessaging.state.logging.StateLogMessages.MAVLINK_STATE_TWIN_CREATED;
 
 public class MavlinkTwinUpdater {
 
@@ -168,6 +167,7 @@ public class MavlinkTwinUpdater {
     droneTwin.setSystemId(env.getFrame().getSystemId());
     droneTwin.setComponentId(env.getFrame().getComponentId());
     droneTwin.setModelName(droneInfo.getModelName());
+    droneTwin.setSurveyRadiusMeters(droneInfo.getSurveyRadiusMeters());
     if(droneInfo.getStopAction() != null) {
       droneTwin.setStopAction(droneInfo.getStopAction());
     }

--- a/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkCommandLongFactory.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/messages/MavlinkCommandLongFactory.java
@@ -27,6 +27,7 @@ public final class MavlinkCommandLongFactory {
   public static final int MAV_CMD_DO_ORBIT = 34;
   public static final int MAV_CMD_DO_SET_MODE = 176;
   public static final int MAV_CMD_DO_PAUSE_CONTINUE = 193;
+  public static final int MAV_CMD_DO_SET_MISSION_CURRENT = 224;
   public static final int MAV_CMD_MISSION_START = 300;
   public static final int MAV_CMD_COMPONENT_ARM_DISARM = 400;
 
@@ -124,6 +125,29 @@ public final class MavlinkCommandLongFactory {
 
     commandLong.setParam1(firstMissionItem);
     commandLong.setParam2(lastMissionItem);
+    return commandLong;
+  }
+
+  public static MavlinkCommandLong setMissionCurrent(
+      int targetSystem,
+      int targetComponent,
+      int sequence,
+      int missionSequence,
+      boolean resetMission) {
+
+    if (missionSequence < -1) {
+      throw new IllegalArgumentException("missionSequence must be -1 or greater");
+    }
+
+    MavlinkCommandLong commandLong =
+        command(
+            targetSystem,
+            targetComponent,
+            MAV_CMD_DO_SET_MISSION_CURRENT,
+            sequence);
+
+    commandLong.setParam1(missionSequence);
+    commandLong.setParam2(resetMission ? 1.0f : 0.0f);
     return commandLong;
   }
 

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/UxvModel.java
@@ -51,6 +51,10 @@ public interface UxvModel {
     return false;
   }
 
+  default int firstMissionItemSequence() {
+    return 0;
+  }
+
   default Optional<DetectionEvent> interpretDetection(DroneTwin droneTwin, MavlinkPacket event) {
     return Optional.empty();
   }

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/impl/ardupilot/GenericArduPilotUxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/impl/ardupilot/GenericArduPilotUxvModel.java
@@ -19,22 +19,67 @@
 
 package io.mapsmessaging.state.mavlink.model.impl.ardupilot;
 
+import io.mapsmessaging.state.drone.model.GeoPosition;
 import io.mapsmessaging.state.mavlink.messages.MavlinkCommandLongFactory;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMessage;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemIntFactory;
+import io.mapsmessaging.state.mavlink.model.MissionPlan;
+import io.mapsmessaging.state.mavlink.model.PlanItem;
+import io.mapsmessaging.state.mavlink.model.PlanValidation;
 import io.mapsmessaging.state.mavlink.model.UxvCommandContext;
 import io.mapsmessaging.state.mavlink.model.UxvModelCommandSet;
 import io.mapsmessaging.state.mavlink.model.UxvOperation;
 import io.mapsmessaging.state.mavlink.model.UxvVehicleType;
 import io.mapsmessaging.state.mavlink.model.impl.AbstractMissionUxvModel;
-
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public abstract class GenericArduPilotUxvModel extends AbstractMissionUxvModel {
 
+  private static final int HOME_MISSION_SEQUENCE = 0;
+  private static final int FIRST_REAL_MISSION_SEQUENCE = 1;
+
   protected GenericArduPilotUxvModel(String modelName, UxvVehicleType vehicleType, Set<UxvOperation> supportedOperations) {
     super(modelName, vehicleType, supportedOperations);
   }
 
+  @Override
+  public int firstMissionItemSequence() {
+    return FIRST_REAL_MISSION_SEQUENCE;
+  }
+
+  @Override
+  public UxvModelCommandSet buildMission(UxvCommandContext context, MissionPlan missionPlan) {
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(missionPlan, "missionPlan must not be null");
+
+    PlanValidation validation = validateMission(missionPlan);
+    if (!validation.valid()) {
+      throw new IllegalArgumentException("Invalid mission plan: " + validation.issues());
+    }
+
+    int additionalItems = FIRST_REAL_MISSION_SEQUENCE + (missionPlan.repeats() ? 1 : 0);
+    List<MavlinkMessage> messages = new ArrayList<>(missionPlan.items().size() + additionalItems);
+    messages.add(homeMissionItem(context, missionPlan));
+
+    for (int index = 0; index < missionPlan.items().size(); index++) {
+      messages.add(toMissionMessage(context, index + FIRST_REAL_MISSION_SEQUENCE, missionPlan.items().get(index)));
+    }
+
+    if (missionPlan.repeats()) {
+      messages.add(
+          MavlinkMissionItemIntFactory.jump(
+              context.targetSystem(),
+              context.targetComponent(),
+              missionPlan.items().size() + FIRST_REAL_MISSION_SEQUENCE,
+              FIRST_REAL_MISSION_SEQUENCE,
+              missionPlan.jumpRepeatCount()));
+    }
+
+    return UxvModelCommandSet.of(UxvOperation.BUILD_MISSION, getModelName(), messages);
+  }
 
   @Override
   public UxvModelCommandSet returnToHome(UxvCommandContext context) {
@@ -45,4 +90,18 @@ public abstract class GenericArduPilotUxvModel extends AbstractMissionUxvModel {
         MavlinkCommandLongFactory.returnToLaunch(context.targetSystem(), context.targetComponent(), context.sequence()));
   }
 
+  private MavlinkMessage homeMissionItem(UxvCommandContext context, MissionPlan missionPlan) {
+    GeoPosition placeholderPosition =
+        missionPlan.items().stream()
+            .map(PlanItem::position)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElseGet(() -> new GeoPosition(0.0d, 0.0d, 0.0d, null));
+
+    return MavlinkMissionItemIntFactory.waypoint(
+        context.targetSystem(),
+        context.targetComponent(),
+        HOME_MISSION_SEQUENCE,
+        placeholderPosition);
+  }
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/model/impl/ardupilot/GenericArduPilotUxvModel.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/model/impl/ardupilot/GenericArduPilotUxvModel.java
@@ -82,6 +82,24 @@ public abstract class GenericArduPilotUxvModel extends AbstractMissionUxvModel {
   }
 
   @Override
+  public UxvModelCommandSet startMission(UxvCommandContext context) {
+    Objects.requireNonNull(context, "context must not be null");
+    List<MavlinkMessage> messages =
+        List.of(
+            MavlinkCommandLongFactory.setMissionCurrent(
+                context.targetSystem(),
+                context.targetComponent(),
+                context.sequence(),
+                FIRST_REAL_MISSION_SEQUENCE,
+                true),
+            MavlinkCommandLongFactory.missionStart(
+                context.targetSystem(),
+                context.targetComponent(),
+                context.sequence()));
+    return UxvModelCommandSet.of(UxvOperation.START_MISSION, getModelName(), messages);
+  }
+
+  @Override
   public UxvModelCommandSet returnToHome(UxvCommandContext context) {
     Objects.requireNonNull(context, "context must not be null");
     return UxvModelCommandSet.of(

--- a/src/test/java/io/mapsmessaging/state/config/DroneSurveyRadiusConfigurationTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/DroneSurveyRadiusConfigurationTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ */
+
+package io.mapsmessaging.state.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.google.gson.Gson;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import org.junit.jupiter.api.Test;
+
+class DroneSurveyRadiusConfigurationTest {
+
+  @Test
+  void surveyRadiusDeserializesAndCanBePropagatedToTwin() {
+    DroneInfoDTO configured =
+        new Gson().fromJson("{\"surveyRadiusMeters\":200.0}", DroneInfoDTO.class);
+
+    DroneTwin twin = new DroneTwin("survey-drone");
+    twin.setSurveyRadiusMeters(configured.getSurveyRadiusMeters());
+
+    assertEquals(200.0d, configured.getSurveyRadiusMeters());
+    assertEquals(200.0d, twin.getSurveyRadiusMeters());
+    assertEquals(400.0d, twin.getSurveyRadiusMeters() * 2.0d);
+  }
+
+  @Test
+  void surveyRadiusRemainsOptional() {
+    DroneInfoDTO configured = new Gson().fromJson("{}", DroneInfoDTO.class);
+    DroneTwin twin = new DroneTwin("non-survey-drone");
+    twin.setSurveyRadiusMeters(configured.getSurveyRadiusMeters());
+
+    assertNull(configured.getSurveyRadiusMeters());
+    assertNull(twin.getSurveyRadiusMeters());
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/model/ArduPilotMissionSequenceTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/model/ArduPilotMissionSequenceTest.java
@@ -20,6 +20,8 @@ package io.mapsmessaging.state.mavlink.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.mapsmessaging.state.drone.model.GeoPosition;
+import io.mapsmessaging.state.mavlink.messages.MavlinkCommandLong;
+import io.mapsmessaging.state.mavlink.messages.MavlinkCommandLongFactory;
 import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemInt;
 import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemIntFactory;
 import io.mapsmessaging.state.mavlink.model.impl.uav.GenericPx4UavModel;
@@ -62,6 +64,25 @@ class ArduPilotMissionSequenceTest {
   }
 
   @Test
+  void ardupilotResetsMissionPointerBeforeStartingMission() {
+    SticklebackArdupilotUsvModel model = new SticklebackArdupilotUsvModel();
+
+    UxvModelCommandSet commandSet = model.startMission(CONTEXT);
+
+    assertEquals(2, commandSet.messages().size());
+
+    MavlinkCommandLong setCurrent = (MavlinkCommandLong) commandSet.messages().get(0);
+    assertEquals(MavlinkCommandLongFactory.MAV_CMD_DO_SET_MISSION_CURRENT, setCurrent.getCommand());
+    assertEquals(1.0f, setCurrent.getParam1());
+    assertEquals(1.0f, setCurrent.getParam2());
+
+    MavlinkCommandLong start = (MavlinkCommandLong) commandSet.messages().get(1);
+    assertEquals(MavlinkCommandLongFactory.MAV_CMD_MISSION_START, start.getCommand());
+    assertEquals(0.0f, start.getParam1());
+    assertEquals(0.0f, start.getParam2());
+  }
+
+  @Test
   void px4KeepsFirstRoutePointAtSequenceZero() {
     GenericPx4UavModel model = new GenericPx4UavModel();
 
@@ -71,6 +92,17 @@ class ArduPilotMissionSequenceTest {
     assertEquals(2, commandSet.messages().size());
     assertMissionItem(commandSet, 0, 0, FIRST);
     assertMissionItem(commandSet, 1, 1, LAST);
+  }
+
+  @Test
+  void px4StartsMissionWithoutArduPilotPointerReset() {
+    GenericPx4UavModel model = new GenericPx4UavModel();
+
+    UxvModelCommandSet commandSet = model.startMission(CONTEXT);
+
+    assertEquals(1, commandSet.messages().size());
+    MavlinkCommandLong start = (MavlinkCommandLong) commandSet.messages().get(0);
+    assertEquals(MavlinkCommandLongFactory.MAV_CMD_MISSION_START, start.getCommand());
   }
 
   private List<PlanItem> routeItems() {

--- a/src/test/java/io/mapsmessaging/state/mavlink/model/ArduPilotMissionSequenceTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/model/ArduPilotMissionSequenceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.mapsmessaging.state.drone.model.GeoPosition;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemInt;
+import io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemIntFactory;
+import io.mapsmessaging.state.mavlink.model.impl.uav.GenericPx4UavModel;
+import io.mapsmessaging.state.mavlink.model.impl.usv.SticklebackArdupilotUsvModel;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ArduPilotMissionSequenceTest {
+
+  private static final UxvCommandContext CONTEXT = new UxvCommandContext(UUID.randomUUID(), 1, 1, 255, 190, 7);
+  private static final GeoPosition FIRST = new GeoPosition(59.4877408d, 24.8089485d, 10.0d, null);
+  private static final GeoPosition LAST = new GeoPosition(59.4785881d, 24.8086052d, 10.0d, null);
+
+  @Test
+  void ardupilotReservesSequenceZeroAndStartsRouteAtSequenceOne() {
+    SticklebackArdupilotUsvModel model = new SticklebackArdupilotUsvModel();
+
+    UxvModelCommandSet commandSet = model.buildMission(CONTEXT, new MissionPlan(routeItems()));
+
+    assertEquals(1, model.firstMissionItemSequence());
+    assertEquals(3, commandSet.messages().size());
+    assertMissionItem(commandSet, 0, 0, FIRST);
+    assertMissionItem(commandSet, 1, 1, FIRST);
+    assertMissionItem(commandSet, 2, 2, LAST);
+  }
+
+  @Test
+  void ardupilotRepeatJumpsToFirstRealMissionItem() {
+    SticklebackArdupilotUsvModel model = new SticklebackArdupilotUsvModel();
+
+    UxvModelCommandSet commandSet = model.buildMission(CONTEXT, MissionPlan.repeatIndefinitely(routeItems()));
+
+    assertEquals(4, commandSet.messages().size());
+    MavlinkMissionItemInt jump = (MavlinkMissionItemInt) commandSet.messages().get(3);
+    assertEquals(3, jump.getMissionSequence());
+    assertEquals(MavlinkMissionItemIntFactory.MAV_CMD_DO_JUMP, jump.getCommand());
+    assertEquals(1.0f, jump.getParam1());
+    assertEquals(MavlinkMissionItemIntFactory.MAV_CMD_DO_JUMP_REPEAT_FOREVER, (int) jump.getParam2());
+  }
+
+  @Test
+  void px4KeepsFirstRoutePointAtSequenceZero() {
+    GenericPx4UavModel model = new GenericPx4UavModel();
+
+    UxvModelCommandSet commandSet = model.buildMission(CONTEXT, new MissionPlan(routeItems()));
+
+    assertEquals(0, model.firstMissionItemSequence());
+    assertEquals(2, commandSet.messages().size());
+    assertMissionItem(commandSet, 0, 0, FIRST);
+    assertMissionItem(commandSet, 1, 1, LAST);
+  }
+
+  private List<PlanItem> routeItems() {
+    return List.of(waypoint(FIRST), waypoint(LAST));
+  }
+
+  private PlanItem waypoint(GeoPosition position) {
+    return new PlanItem(PlanItemType.WAYPOINT, position, null, null, null, null, null, null);
+  }
+
+  private void assertMissionItem(UxvModelCommandSet commandSet, int messageIndex, int missionSequence, GeoPosition position) {
+    MavlinkMissionItemInt item = (MavlinkMissionItemInt) commandSet.messages().get(messageIndex);
+    assertEquals(missionSequence, item.getMissionSequence());
+    assertEquals(MavlinkMissionItemIntFactory.MAV_CMD_NAV_WAYPOINT, item.getCommand());
+    assertEquals((int) Math.round(position.getLatitude() * 10_000_000.0d), item.getLatitude());
+    assertEquals((int) Math.round(position.getLongitude() * 10_000_000.0d), item.getLongitude());
+  }
+}


### PR DESCRIPTION
## Summary

Extend the existing ArduPilot mission-sequence branch with per-drone survey coverage configuration required by STANAG SURVEY execution.

## Survey configuration

- add optional `surveyRadiusMeters` to `DroneInfoDTO`
- expose the same typed value on `DroneTwin`
- propagate the configured radius when MAVLink creates a drone twin
- define the value as the coverage radius measured from the vehicle centreline
- derive effective survey width as `surveyRadiusMeters * 2`
- do not invent a default radius

A configured radius of `200 m` therefore represents a `400 m` full survey width and default survey-track spacing.

## Existing branch scope

This branch also contains the coordinated ArduPilot mission-sequence work already present before the survey change, including the model mission-item sequence contract and associated tests. The adapter SURVEY branch relies on those APIs when monitoring generated missions.

## Tests

Add focused coverage proving that:

- `surveyRadiusMeters` deserializes from drone configuration
- the value can be propagated to `DroneTwin`
- a `200 m` radius produces a `400 m` effective width
- the field remains optional for drones that do not support SURVEY

## Coordinated adapter change

`Maps-Messaging/stanag-state-adapter` branch `agent/survey-coverage-planning` consumes `DroneTwin.getSurveyRadiusMeters()` to generate one-shot back-and-forth area coverage missions.

## Validation

The branch is cleanly based on `development` and is currently 10 commits ahead and 0 behind. No GitHub commit-status checks are exposed for the branch in this environment, so the normal Maven/Buildkite validation is still required before merge.