### PR TITLE
Use hold position for task completion

### DIFF
--- a/src/main/java/io/mapsmessaging/state/config/StopActionEnum.java
+++ b/src/main/java/io/mapsmessaging/state/config/StopActionEnum.java
@@ -23,14 +23,18 @@ public enum StopActionEnum {
   HOLD_POSITION,
   RETURN_TO_HOME,
 
-  /**
-   * Legacy configuration value. Interpreted as {@link #HOLD_POSITION} so that an aircraft is
-   * never instructed to literally stop moving.
-   */
+  /** Legacy configuration value interpreted as {@link #HOLD_POSITION}. */
   @Deprecated
-  STOP;
+  STOP,
+
+  /** Legacy completion value interpreted as {@link #HOLD_POSITION}. */
+  @Deprecated
+  ORBIT;
 
   public StopActionEnum normalized() {
-    return this == STOP ? HOLD_POSITION : this;
+    return switch (this) {
+      case STOP, ORBIT -> HOLD_POSITION;
+      case HOLD_POSITION, RETURN_TO_HOME -> this;
+    };
   }
 }

--- a/src/main/java/io/mapsmessaging/state/config/StopActionEnum.java
+++ b/src/main/java/io/mapsmessaging/state/config/StopActionEnum.java
@@ -20,7 +20,17 @@
 package io.mapsmessaging.state.config;
 
 public enum StopActionEnum {
-  STOP,
-  ORBIT,
-  RETURN_TO_HOME;
+  HOLD_POSITION,
+  RETURN_TO_HOME,
+
+  /**
+   * Legacy configuration value. Interpreted as {@link #HOLD_POSITION} so that an aircraft is
+   * never instructed to literally stop moving.
+   */
+  @Deprecated
+  STOP;
+
+  public StopActionEnum normalized() {
+    return this == STOP ? HOLD_POSITION : this;
+  }
 }


### PR DESCRIPTION
## What changed

- Added `HOLD_POSITION` as the safe task completion action.
- Preserved legacy `STOP` and `ORBIT` configuration values for compatibility.
- Normalised both legacy values to `HOLD_POSITION`.
- Kept `RETURN_TO_HOME` as the alternative completion action.

## Why

A generic `STOP` action is unsafe and ambiguous for aircraft, especially fixed-wing vehicles. Task completion should transition the vehicle into a model-specific hold behaviour rather than imply zero movement.

## Integration

The companion `stanag-state-adapter` branch `agent/task-duration-lifecycle` uses `normalized()` and resolves the final command through each model's `holdPosition()` or `returnToHome()` implementation.

## Validation

Source review only. The companion adapter branch must build against this change before its tests can run successfully.