### PR TITLE
Verify Stickleback stop command

### DIFF
--- a/src/test/java/io/mapsmessaging/state/mavlink/model/impl/usv/SticklebackArdupilotUsvStopTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/model/impl/usv/SticklebackArdupilotUsvStopTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ */
+
+package io.mapsmessaging.state.mavlink.model.impl.usv;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.mapsmessaging.state.mavlink.messages.MavlinkCommandInt;
+import io.mapsmessaging.state.mavlink.messages.MavlinkCommandIntFactory;
+import io.mapsmessaging.state.mavlink.model.UxvCommandContext;
+import io.mapsmessaging.state.mavlink.model.UxvModelCommandSet;
+import io.mapsmessaging.state.mavlink.model.UxvOperation;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class SticklebackArdupilotUsvStopTest {
+
+  @Test
+  void stopUsesUnlimitedLoiterAtCurrentPosition() {
+    SticklebackArdupilotUsvModel model = new SticklebackArdupilotUsvModel();
+    UxvCommandContext context =
+        new UxvCommandContext(
+            UUID.fromString("a1eef2cf-7dc2-5655-9aed-9ed6cee64345"),
+            10,
+            1,
+            255,
+            190,
+            23);
+
+    UxvModelCommandSet commandSet = model.stop(context);
+
+    assertEquals(UxvOperation.STOP, commandSet.operation());
+    assertEquals(SticklebackArdupilotUsvModel.MODEL_NAME, commandSet.modelName());
+    assertEquals(1, commandSet.messages().size());
+    assertTrue(commandSet.messages().get(0) instanceof MavlinkCommandInt);
+
+    MavlinkCommandInt command = (MavlinkCommandInt) commandSet.messages().get(0);
+    assertEquals(MavlinkCommandInt.MESSAGE_ID_COMMAND_INT, command.getMessageId());
+    assertEquals(MavlinkCommandIntFactory.MAV_CMD_NAV_LOITER_UNLIM, command.getCommand());
+    assertEquals(MavlinkCommandIntFactory.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT, command.getFrame());
+    assertEquals(10, command.getTargetSystem());
+    assertEquals(1, command.getTargetComponent());
+    assertEquals(23, command.getSequence());
+    assertEquals(0, command.getLatitude());
+    assertEquals(0, command.getLongitude());
+    assertEquals(0.0f, command.getAltitude());
+  }
+}


### PR DESCRIPTION
## Summary

- add a focused regression test for the Stickleback USV stop command
- verify STOP produces COMMAND_INT / MAV_CMD_NAV_LOITER_UNLIM
- verify the command targets the configured system/component and uses current-position semantics

## Why

The generic HOLD_POSITION path uses ArduPilot pause/continue and is temporarily rejected by the Stickleback fixed-wing firmware. The coordinated adapter PR now selects the model's dedicated STOP command for hold-position completion.

## Coordination

Paired with `Maps-Messaging/stanag-state-adapter` branch `agent/stickleback-stop-preemption`.

## Base

`development`