### PR TITLE
Harden MAVLink transport and state lifecycle

### DIFF
--- a/src/main/java/io/mapsmessaging/network/io/impl/udp/UDPFacadeEndPoint.java
+++ b/src/main/java/io/mapsmessaging/network/io/impl/udp/UDPFacadeEndPoint.java
@@ -32,6 +32,7 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class UDPFacadeEndPoint extends EndPoint {
@@ -40,11 +41,13 @@ public class UDPFacadeEndPoint extends EndPoint {
 
   private final EndPoint endPoint;
   private final SocketAddress fromAddress;
+  private final AtomicBoolean closed;
 
   public UDPFacadeEndPoint(EndPoint endPoint, SocketAddress fromAddress, EndPointServerStatus server) {
     super(counter.incrementAndGet(), server);
     this.endPoint = endPoint;
     this.fromAddress = fromAddress;
+    closed = new AtomicBoolean(false);
     List<String> end = new ArrayList<>(endPoint.getJMXTypePath());
     end.remove(end.size() - 1);
 
@@ -53,7 +56,7 @@ public class UDPFacadeEndPoint extends EndPoint {
     String remote = strip("remoteHost=" + getName());
     end.add(remote);
     jmxParentPath = end;
-    EndPointServer endPointServer = (EndPointServer)server;
+    EndPointServer endPointServer = (EndPointServer) server;
     endPointServer.registerNewEndPoint(this);
   }
 
@@ -71,16 +74,25 @@ public class UDPFacadeEndPoint extends EndPoint {
 
   @Override
   public int sendPacket(Packet packet) throws IOException {
+    if (closed.get()) {
+      throw new IOException("UDP facade endpoint is closed");
+    }
     return endPoint.sendPacket(packet);
   }
 
   @Override
   public int readPacket(Packet packet) throws IOException {
+    if (closed.get()) {
+      return -1;
+    }
     return endPoint.readPacket(packet);
   }
 
   @Override
   public FutureTask<SelectionKey> register(int selectionKey, Selectable runner) throws IOException {
+    if (closed.get()) {
+      throw new ClosedChannelException();
+    }
     return endPoint.register(selectionKey, runner);
   }
 
@@ -96,7 +108,7 @@ public class UDPFacadeEndPoint extends EndPoint {
 
   @Override
   public String getName() {
-    return "udp:/" + fromAddress.toString();
+    return "udp:/" + fromAddress;
   }
 
   @Override
@@ -109,16 +121,18 @@ public class UDPFacadeEndPoint extends EndPoint {
     return fromAddress.toString();
   }
 
-
   @Override
   public void close() throws IOException {
-    endPoint.close();
-    EndPointServer endPointServer = (EndPointServer)endPoint.getServer();
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    super.close();
+    EndPointServer endPointServer = (EndPointServer) endPoint.getServer();
     endPointServer.handleCloseEndPoint(this);
   }
 
   @Override
-  public boolean isClient(){
+  public boolean isClient() {
     return endPoint.isClient();
   }
 
@@ -141,6 +155,4 @@ public class UDPFacadeEndPoint extends EndPoint {
   public boolean isSSL() {
     return endPoint.isSSL();
   }
-
-
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkInterfaceManager.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkInterfaceManager.java
@@ -19,7 +19,6 @@
 
 package io.mapsmessaging.network.protocol.impl.mavlink;
 
-import static io.mapsmessaging.logging.ServerLogMessages.MAVLINK_DETECTED_PACKET;
 import static io.mapsmessaging.logging.ServerLogMessages.MAVLINK_FAILED_FORWARD_PACKET;
 import static io.mapsmessaging.logging.ServerLogMessages.MAVLINK_FAILED_PARSING_FORWARD_LIST;
 import static io.mapsmessaging.logging.ServerLogMessages.MAVLINK_FAILED_SETTING_UP_SESSION;
@@ -30,7 +29,6 @@ import io.mapsmessaging.config.protocol.impl.MavlinkConfig;
 import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.mavlink.MavlinkEventFactory;
-import io.mapsmessaging.mavlink.ProcessedFrame;
 import io.mapsmessaging.mavlink.tlog.MavlinkTlogWriter;
 import io.mapsmessaging.mavlink.tlog.TlogConfiguration;
 import io.mapsmessaging.network.io.EndPoint;
@@ -39,8 +37,6 @@ import io.mapsmessaging.network.io.impl.SelectorCallback;
 import io.mapsmessaging.network.io.impl.SelectorTask;
 import io.mapsmessaging.network.io.impl.udp.UDPFacadeEndPoint;
 import io.mapsmessaging.network.io.impl.udp.session.UDPSessionState;
-import lombok.Getter;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -52,7 +48,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 
 public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnectionManager {
 
@@ -61,7 +56,6 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
   private final SelectorTask selectorTask;
   private final EndPoint endPoint;
   private final MavLinkSessionManager<MavlinkProtocol> currentSessions;
-  private final MavlinkEventFactory mavlinkEventFactory;
   private final MavlinkConfig mavlinkConfig;
   private final List<InetSocketAddress> forwardList;
   private final MavlinkTlogWriter tlogWriter;
@@ -69,9 +63,7 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
   public MavlinkInterfaceManager(EndPoint endPoint) throws IOException {
     this.endPoint = endPoint;
     mavlinkConfig = (MavlinkConfig) endPoint.getConfig().getProtocolConfig("mavlink");
-    long timeout = mavlinkConfig.getIdleSessionTimeout();
-    mavlinkEventFactory = loadDialect(mavlinkConfig.getDialectName());
-    currentSessions = new MavLinkSessionManager<>(timeout);
+    currentSessions = new MavLinkSessionManager<>(mavlinkConfig.getIdleSessionTimeout());
     selectorTask = new SelectorTask(this, endPoint.getConfig().getEndPointConfig(), endPoint.isUDP());
     selectorTask.register(SelectionKey.OP_READ);
 
@@ -84,7 +76,7 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
           try {
             URI uri = URI.create(remote);
             forwardList.add(new InetSocketAddress(uri.getHost(), uri.getPort()));
-          } catch (Exception e) {
+          } catch (RuntimeException e) {
             logger.log(MAVLINK_FAILED_PARSING_FORWARD_LIST, remote, e);
           }
         }
@@ -103,40 +95,51 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
 
   @Override
   public boolean processPacket(Packet packet) throws IOException {
-    if (packet.getFromAddress() == null) {
-      return true;
-    }
-
-    byte[] raw = new byte[packet.available()];
-    int pos = packet.position();
-    packet.get(raw);
-    packet.position(pos);
-
-    List<byte[]> packets = MavlinkFrameExtractor.extractMavlinkFrames(raw);
-    for(byte[] data:packets) {
-      writeTlog(data);
-      int systemId = MavlinkFrameExtractor.getSystemId(data);
-      MavlinkDeviceKey key = buildKey(packet, systemId);
-      boolean allowed =
-          mavlinkConfig.getAcceptedSources() == null
-              || mavlinkConfig.getAcceptedSources().isEmpty()
-              || mavlinkConfig.getAcceptedSources().stream().anyMatch(knownSource -> knownSource.getSystemId() == key.getSystemId());
-
-      if (allowed) {
-        UDPSessionState<MavlinkProtocol> state = findOrCreate(key);
-        if (fromForward(packet)) {
-          state.getContext().processPacket(packet);
-        } else if (state.getContext() != null) {
-          MavlinkProtocol protocol = state.getContext();
-          protocol.processRawFrame(data, packet.getFromAddress().toString());
-          forwardPacket(data);
-        }
-      } else {
-        forwardPacket(data);
+    try {
+      SocketAddress fromAddress = packet.getFromAddress();
+      if (fromAddress == null) {
+        return true;
       }
+
+      byte[] raw = new byte[packet.available()];
+      int position = packet.position();
+      packet.get(raw);
+      packet.position(position);
+
+      boolean forwardedSource = fromForward(fromAddress);
+      for (byte[] frame : MavlinkFrameExtractor.extractMavlinkFrames(raw)) {
+        writeTlog(frame);
+        int systemId = MavlinkFrameExtractor.getSystemId(frame);
+        MavlinkDeviceKey key = buildKey(packet, systemId);
+
+        if (!isAllowedSystem(systemId)) {
+          if (!forwardedSource) {
+            forwardPacket(frame);
+          }
+          continue;
+        }
+
+        UDPSessionState<MavlinkProtocol> state = findOrCreate(key);
+        if (state == null || state.getContext() == null) {
+          continue;
+        }
+
+        state.getContext().processRawFrame(frame, fromAddress.toString());
+        if (!forwardedSource) {
+          forwardPacket(frame);
+        }
+      }
+      return true;
+    } finally {
+      selectorTask.register(SelectionKey.OP_READ);
     }
-    selectorTask.register(SelectionKey.OP_READ);
-    return true;
+  }
+
+  private boolean isAllowedSystem(int systemId) {
+    return mavlinkConfig.getAcceptedSources() == null
+        || mavlinkConfig.getAcceptedSources().isEmpty()
+        || mavlinkConfig.getAcceptedSources().stream()
+            .anyMatch(knownSource -> knownSource.getSystemId() == systemId);
   }
 
   private MavlinkTlogWriter createTlogWriter() throws IOException {
@@ -149,8 +152,7 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
     if (!fileName.toLowerCase(Locale.ROOT).endsWith(".tlog")) {
       fileName += ".tlog";
     }
-    fileName = toSafeFileName(fileName);
-    Path tlogFile = Path.of(tlogDirectory).resolve(fileName);
+    Path tlogFile = Path.of(tlogDirectory).resolve(toSafeFileName(fileName));
     return new MavlinkTlogWriter(TlogConfiguration.builder(tlogFile).build());
   }
 
@@ -171,29 +173,35 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
 
   private synchronized UDPSessionState<MavlinkProtocol> findOrCreate(MavlinkDeviceKey key) {
     UDPSessionState<MavlinkProtocol> state = currentSessions.getState(key);
-    if (state == null) {
-      UDPFacadeEndPoint facade = new UDPFacadeEndPoint(endPoint, key.getRemoteAddress(), endPoint.getServer());
-      try {
-        MavlinkProtocol protocol = new MavlinkProtocol(this, key, facade, this.mavlinkConfig);
-        state = new UDPSessionState<>(protocol);
-        currentSessions.addState(key, state);
-        logger.log(MAVLINK_SESSION_CREATED, key.toString());
-      } catch (IOException e) {
-        logger.log(MAVLINK_FAILED_SETTING_UP_SESSION, key.toString(), e);
-      }
+    if (state != null) {
+      return state;
     }
-    return state;
+
+    UDPFacadeEndPoint facade = new UDPFacadeEndPoint(endPoint, key.getRemoteAddress(), endPoint.getServer());
+    try {
+      MavlinkProtocol protocol = new MavlinkProtocol(this, key, facade, mavlinkConfig);
+      state = new UDPSessionState<>(protocol);
+      currentSessions.addState(key, state);
+      logger.log(MAVLINK_SESSION_CREATED, key.toString());
+      return state;
+    } catch (IOException | RuntimeException e) {
+      try {
+        facade.close();
+      } catch (IOException closeException) {
+        e.addSuppressed(closeException);
+      }
+      logger.log(MAVLINK_FAILED_SETTING_UP_SESSION, key.toString(), e);
+      return null;
+    }
   }
 
-  private boolean fromForward(Packet packet) {
-    SocketAddress fromAddress = packet.getFromAddress();
+  private boolean fromForward(SocketAddress fromAddress) {
     return forwardList.stream().anyMatch(forwardAddress -> forwardAddress.equals(fromAddress));
   }
 
   private void forwardPacket(byte[] raw) {
     for (SocketAddress socketAddress : forwardList) {
-      ByteBuffer byteBuffer = ByteBuffer.wrap(raw);
-      Packet forward = new Packet(byteBuffer);
+      Packet forward = new Packet(ByteBuffer.wrap(raw));
       forward.setFromAddress(socketAddress);
       try {
         endPoint.sendPacket(forward);
@@ -235,6 +243,7 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
     return endPoint;
   }
 
+  @Override
   public void close(MavlinkDeviceKey remoteClient) {
     currentSessions.deleteState(remoteClient);
   }
@@ -249,7 +258,6 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
 
     for (int i = 0; i < value.length(); i++) {
       char character = value.charAt(i);
-
       if (Character.isLetterOrDigit(character) || character == '-' || character == '.') {
         safe.append(character);
         previousUnderscore = false;
@@ -261,19 +269,13 @@ public class MavlinkInterfaceManager implements SelectorCallback, MavlinkConnect
 
     int start = 0;
     int end = safe.length();
-
     while (start < end && (safe.charAt(start) == '.' || safe.charAt(start) == '_')) {
       start++;
     }
-
     while (end > start && (safe.charAt(end - 1) == '.' || safe.charAt(end - 1) == '_')) {
       end--;
     }
 
-    if (start == end) {
-      return "mavlink";
-    }
-
-    return safe.substring(start, end);
+    return start == end ? "mavlink" : safe.substring(start, end);
   }
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkProtocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkProtocol.java
@@ -31,7 +31,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.mapsmessaging.api.Destination;
-import io.mapsmessaging.api.GsonFactory;
 import io.mapsmessaging.api.MessageBuilder;
 import io.mapsmessaging.api.MessageEvent;
 import io.mapsmessaging.api.Session;
@@ -135,7 +134,7 @@ public class MavlinkProtocol extends Protocol {
 
     storeOffline = mavlinkConfig.isStoreOffline();
     qos = QualityOfService.getInstance(mavlinkConfig.getQualityOfService());
-    gson = io.mapsmessaging.network.protocol.impl.mavlink.GsonFactory.createStrictJsonWithSafeFloats();
+    gson = GsonFactory.createStrictJsonWithSafeFloats();
 
     try {
       session =

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkProtocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkProtocol.java
@@ -30,7 +30,13 @@ import static io.mapsmessaging.logging.ServerLogMessages.MAVLINK_OUTBOUND_MESSAG
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import io.mapsmessaging.api.*;
+import io.mapsmessaging.api.Destination;
+import io.mapsmessaging.api.GsonFactory;
+import io.mapsmessaging.api.MessageBuilder;
+import io.mapsmessaging.api.MessageEvent;
+import io.mapsmessaging.api.Session;
+import io.mapsmessaging.api.SessionManager;
+import io.mapsmessaging.api.SubscriptionContextBuilder;
 import io.mapsmessaging.api.features.ClientAcknowledgement;
 import io.mapsmessaging.api.features.DestinationType;
 import io.mapsmessaging.api.features.QualityOfService;
@@ -54,24 +60,30 @@ import io.mapsmessaging.network.protocol.impl.mavlink.monitor.SequenceTracker;
 import io.mapsmessaging.schemas.config.impl.MavlinkSchemaConfig;
 import io.mapsmessaging.schemas.formatters.MessageFormatter;
 import io.mapsmessaging.schemas.formatters.MessageFormatterFactory;
+import io.mapsmessaging.utilities.threads.SimpleTaskScheduler;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.security.auth.Subject;
-
-import io.mapsmessaging.utilities.threads.SimpleTaskScheduler;
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
 
 public class MavlinkProtocol extends Protocol {
 
   private static final int MAV_AUTOPILOT_ARDUPILOTMEGA = 3;
-  private static final int MAV_AUTOPILOT_PX4           = 12;
-  private static final int MAV_AUTOPILOT_INVALID       = 8;
+  private static final int MAV_AUTOPILOT_PX4 = 12;
 
   private static final Logger logger = LoggerFactory.getLogger(MavlinkProtocol.class);
 
@@ -81,17 +93,16 @@ public class MavlinkProtocol extends Protocol {
   protected final MavlinkConfigDTO mavlinkConfig;
   protected Session session;
   private final Map<Integer, MavlinkAcceptedSourceDTO> acceptedComponents;
-  private final SequenceTracker tracker;
+  private final Map<Integer, SequenceTracker> sequenceTrackers;
   private final String outboundTopicName;
-  protected MavlinkEventFactory mavlinkEventFactory;
+  protected volatile MavlinkEventFactory mavlinkEventFactory;
   protected final MessageFormatter formatter;
   private final QualityOfService qos;
   private final boolean storeOffline;
   private final AtomicInteger sequenceCounter = new AtomicInteger(0);
   private final MavlinkHeartbeatEmitter heartbeatEmitter;
   private ScheduledFuture<?> heartbeatFuture;
-  private boolean detectedDialect = false;
-
+  private volatile boolean detectedDialect;
 
   protected MavlinkProtocol(
       @NonNull @NotNull MavlinkConnectionManager factory,
@@ -102,8 +113,8 @@ public class MavlinkProtocol extends Protocol {
     super(endPoint, protocolConfig);
     this.factory = factory;
     this.key = key;
-    tracker = new SequenceTracker();
-    this.mavlinkConfig = (MavlinkConfigDTO) protocolConfig;
+    sequenceTrackers = new HashMap<>();
+    mavlinkConfig = (MavlinkConfigDTO) protocolConfig;
     String dialectName = mavlinkConfig.getDialectName();
     mavlinkEventFactory = MavlinkInterfaceManager.loadDialect(dialectName);
 
@@ -124,10 +135,17 @@ public class MavlinkProtocol extends Protocol {
 
     storeOffline = mavlinkConfig.isStoreOffline();
     qos = QualityOfService.getInstance(mavlinkConfig.getQualityOfService());
-    gson = GsonFactory.createStrictJsonWithSafeFloats();
+    gson = io.mapsmessaging.network.protocol.impl.mavlink.GsonFactory.createStrictJsonWithSafeFloats();
 
     try {
-      session = buildSession(key.getRemoteAddress().getHostName() + "_" + key.getRemotePort() + "_" + key.getSystemId(), mavlinkConfig.getMaximumSessionExpiry());
+      session =
+          buildSession(
+              key.getRemoteAddress().getHostName()
+                  + "_"
+                  + key.getRemotePort()
+                  + "_"
+                  + key.getSystemId(),
+              mavlinkConfig.getMaximumSessionExpiry());
     } catch (ExecutionException | TimeoutException e) {
       throw new IOException(e);
     } catch (InterruptedException e) {
@@ -138,15 +156,23 @@ public class MavlinkProtocol extends Protocol {
     String outboundTopic = mavlinkConfig.getOutboundTopicName();
     if (outboundTopic != null && !outboundTopic.isEmpty()) {
       outboundTopic = outboundTopic.replace("{interfaceName}", endPoint.getConfig().getName());
-      SubscriptionContextBuilder subscriptionContextBuilder = new SubscriptionContextBuilder(outboundTopic, ClientAcknowledgement.AUTO);
+      SubscriptionContextBuilder subscriptionContextBuilder =
+          new SubscriptionContextBuilder(outboundTopic, ClientAcknowledgement.AUTO);
       subscriptionContextBuilder.setQos(qos);
       subscriptionContextBuilder.setReceiveMaximum(10);
       subscriptionContextBuilder.setNoLocalMessages(true);
       session.addSubscription(subscriptionContextBuilder.build());
     }
     outboundTopicName = outboundTopic;
-    String remoteSocket = endPoint.getRemoteSocketAddress();
-    heartbeatEmitter = new MavlinkHeartbeatEmitter(sequenceCounter, endPoint, mavlinkConfig,  parseSocketAddress(remoteSocket));
+
+    if (mavlinkConfig.hasLocalMavlinkIdentity()) {
+      SocketAddress heartbeatAddress =
+          endPoint.isUDP() ? parseSocketAddress(endPoint.getRemoteSocketAddress()) : null;
+      heartbeatEmitter =
+          new MavlinkHeartbeatEmitter(sequenceCounter, endPoint, mavlinkConfig, heartbeatAddress);
+    } else {
+      heartbeatEmitter = null;
+    }
     startHeartbeatIfConfigured();
   }
 
@@ -188,31 +214,38 @@ public class MavlinkProtocol extends Protocol {
 
       String correlationId = new String(correlationData, StandardCharsets.UTF_8);
       if (!correlationId.startsWith("ID#")) {
-        logger.log(MAVLINK_OUTBOUND_MESSAGE_IGNORED_INVALID_CORRELATION, endPoint.getName(), correlationId);
+        logger.log(
+            MAVLINK_OUTBOUND_MESSAGE_IGNORED_INVALID_CORRELATION,
+            endPoint.getName(),
+            correlationId);
         return;
       }
 
       String[] parts = correlationId.split("#", 3);
       if (parts.length != 3) {
-        logger.log(MAVLINK_OUTBOUND_MESSAGE_IGNORED_INVALID_CORRELATION, endPoint.getName(), correlationId);
+        logger.log(
+            MAVLINK_OUTBOUND_MESSAGE_IGNORED_INVALID_CORRELATION,
+            endPoint.getName(),
+            correlationId);
         return;
       }
 
       String endpointId = Long.toString(endPoint.getId());
       if (!endpointId.equals(parts[1])) {
-        logger.log(MAVLINK_OUTBOUND_MESSAGE_IGNORED_ENDPOINT_MISMATCH, endPoint.getName(), parts[1], endpointId);
+        logger.log(
+            MAVLINK_OUTBOUND_MESSAGE_IGNORED_ENDPOINT_MISMATCH,
+            endPoint.getName(),
+            parts[1],
+            endpointId);
         return;
       }
 
-      String json = new String(messageEvent.getMessage().getOpaqueData(), StandardCharsets.UTF_8);
-      JsonObject input = JsonParser.parseString(json).getAsJsonObject();
-      String socketAddressText = parts[2];
-      sendData(input, socketAddressText);
-    }
-    catch(Throwable th){
-      th.printStackTrace();
-    }
-    finally {
+      String json =
+          new String(messageEvent.getMessage().getOpaqueData(), StandardCharsets.UTF_8);
+      sendData(JsonParser.parseString(json).getAsJsonObject(), parts[2]);
+    } catch (RuntimeException e) {
+      logger.log(MAVLINK_FAILED_SENDING_OUTBOUND_PACKET, endPoint.getName(), "unknown", e);
+    } finally {
       messageEvent.getCompletionTask().run();
     }
   }
@@ -223,11 +256,17 @@ public class MavlinkProtocol extends Protocol {
       validateOutboundHeader(input);
       byte[] frame = formatter.parseFromJson(input);
       Packet packet = new Packet(ByteBuffer.wrap(frame));
-      packet.setFromAddress(parseSocketAddress(socketAddressText));
+      if (endPoint.isUDP()) {
+        packet.setFromAddress(parseSocketAddress(socketAddressText));
+      }
       endPoint.sendPacket(packet);
       factory.writeTlog(frame);
-    } catch (Throwable e) {
-      logger.log(MAVLINK_FAILED_SENDING_OUTBOUND_PACKET, endPoint.getName(), socketAddressText, e);
+    } catch (Exception e) {
+      logger.log(
+          MAVLINK_FAILED_SENDING_OUTBOUND_PACKET,
+          endPoint.getName(),
+          socketAddressText,
+          e);
     }
   }
 
@@ -240,100 +279,138 @@ public class MavlinkProtocol extends Protocol {
   }
 
   @Override
-  public boolean processPacket(@NonNull @NotNull Packet packet) throws IOException {
+  public boolean processPacket(@NonNull @NotNull Packet packet) {
     return true;
   }
 
   public void processRawFrame(byte[] raw, String socketAddress) throws IOException {
     endPoint.getEndPointStatus().incrementReceivedMessages();
     endPoint.updateReadBytes(raw.length);
-    ProcessedFrame env = mavlinkEventFactory.unpack(endPoint.getName(), ByteBuffer.wrap(raw)).orElse(null);
-    if(env == null) {
+    ProcessedFrame env =
+        mavlinkEventFactory.unpack(endPoint.getName(), ByteBuffer.wrap(raw)).orElse(null);
+    if (env == null) {
       return;
     }
-    if(!detectedDialect && env.getFrame().getMessageId() == 0 ){ // HeartBeat
-      detectedDialect = true;
-      if(env.getFields().containsKey("autopilot")) {
-        int val = (int) env.getFields().get("autopilot");
-        try {
-          switch (val) {
-            case MAV_AUTOPILOT_ARDUPILOTMEGA:
-              mavlinkEventFactory = MavlinkInterfaceManager.loadDialect("ardupilot/ardupilotmega");
-              break;
 
-            case MAV_AUTOPILOT_PX4:
-              mavlinkEventFactory = MavlinkInterfaceManager.loadDialect("common");
-              break;
+    detectDialect(env);
+    publishSequenceStatus(env);
 
-            default:
-              // Unknown or unsupported autopilot
-              break;
-          }
-        } catch (IOException e) {
-          e.printStackTrace();
-          // log it
-        }
-      }
-    }
-
-    if (mavlinkConfig.getStatusTopicNameTemplate() != null && !mavlinkConfig.getStatusTopicNameTemplate().isEmpty()) {
-      SequenceResult results = tracker.accept(env.getFrame().getSequence());
-      if (results.isStatusChanged()) {
-        String statusTopic = computeTopicName(mavlinkConfig.getStatusTopicNameTemplate(), env.getFrame(), env.getMessageName());
-        JsonObject resultsJson = gson.toJsonTree(results).getAsJsonObject();
-        MessageBuilder messageBuilder = new MessageBuilder();
-        messageBuilder.setQoS(qos).storeOffline(storeOffline);
-        sendMessage(statusTopic, messageBuilder.setContentType("application/json").setOpaqueData(resultsJson.toString().getBytes(StandardCharsets.UTF_8)).build());
-      }
-    }
-
-    boolean allow = acceptedComponents == null || acceptedComponents.isEmpty() || acceptedComponents.containsKey(env.getFrame().getComponentId());
+    boolean allow =
+        acceptedComponents == null
+            || acceptedComponents.isEmpty()
+            || acceptedComponents.containsKey(env.getFrame().getComponentId());
     if (allow && allowMessageId(env.getFrame().getComponentId(), env.getFrame().getMessageId())) {
       if (mavlinkConfig.isParseToJson()) {
-        Map<String, Object> parsed = env.getFields();
-        JsonObject complete = MavlinkJsonEnvelopeBuilder.toJson(env.getFrame(), parsed);
+        JsonObject complete = MavlinkJsonEnvelopeBuilder.toJson(env.getFrame(), env.getFields());
         JsonObject envelope = new JsonObject();
         envelope.add("mavlink", complete);
         if (env.getDetections() != null && !env.getDetections().isEmpty()) {
           envelope.add("detections", gson.toJsonTree(env.getDetections()).getAsJsonArray());
         }
-        raw = envelope.toString().getBytes();
+        raw = envelope.toString().getBytes(StandardCharsets.UTF_8);
       }
       processPacket(env.getFrame(), env.getMessageName(), raw, socketAddress);
-    } else {
-      if (mavlinkConfig.getRejectedFrameNamespace() != null && !mavlinkConfig.getRejectedFrameNamespace().isEmpty()) {
-        MessageBuilder messageBuilder = new MessageBuilder();
-        messageBuilder.setQoS(qos).storeOffline(storeOffline);
-        if (mavlinkConfig.isIncludeRejectedFrameMetadata()) {
-          JsonObject metadata = new JsonObject();
-          metadata.addProperty("messageName", env.getMessageName());
-          metadata.addProperty("messageId", env.getFrame().getMessageId());
-          metadata.addProperty("systemId", env.getFrame().getSystemId());
-          metadata.addProperty("componentId", env.getFrame().getComponentId());
-          metadata.addProperty("payload", Base64.getEncoder().encodeToString(env.getFrame().getPayload()));
-          metadata.addProperty("sequence", env.getFrame().getSequence());
-          metadata.addProperty("signed", env.getFrame().isSigned());
-          metadata.addProperty("time_ms", System.currentTimeMillis());
-          messageBuilder.setOpaqueData(metadata.toString().getBytes(StandardCharsets.UTF_8));
-        } else {
-          messageBuilder.setOpaqueData(raw);
-        }
-        String topicName = computeTopicName(mavlinkConfig.getRejectedFrameNamespace(), env.getFrame(), env.getMessageName());
-        sendMessage(topicName, messageBuilder.build());
-      }
+      return;
+    }
+
+    publishRejectedFrame(env, raw);
+  }
+
+  private void detectDialect(ProcessedFrame env) {
+    if (detectedDialect || env.getFrame().getMessageId() != 0) {
+      return;
+    }
+    detectedDialect = true;
+
+    Object autopilotValue = env.getFields().get("autopilot");
+    if (!(autopilotValue instanceof Number number)) {
+      return;
+    }
+
+    String dialect =
+        switch (number.intValue()) {
+          case MAV_AUTOPILOT_ARDUPILOTMEGA -> "ardupilot/ardupilotmega";
+          case MAV_AUTOPILOT_PX4 -> "common";
+          default -> null;
+        };
+    if (dialect == null) {
+      return;
+    }
+
+    try {
+      mavlinkEventFactory = MavlinkInterfaceManager.loadDialect(dialect);
+    } catch (IOException e) {
+      logger.log(MAVLINK_FAILED_SENDING_OUTBOUND_PACKET, endPoint.getName(), dialect, e);
     }
   }
 
-  public boolean processPacket(@NonNull @NotNull Frame envelope, String messageName, byte[] raw, String socketAddress) {
+  private void publishSequenceStatus(ProcessedFrame env) {
+    String template = mavlinkConfig.getStatusTopicNameTemplate();
+    if (template == null || template.isEmpty()) {
+      return;
+    }
+
+    SequenceTracker tracker =
+        sequenceTrackers.computeIfAbsent(
+            env.getFrame().getComponentId(), ignored -> new SequenceTracker());
+    SequenceResult results = tracker.accept(env.getFrame().getSequence());
+    if (!results.isStatusChanged()) {
+      return;
+    }
+
+    String statusTopic = computeTopicName(template, env.getFrame(), env.getMessageName());
+    JsonObject resultsJson = gson.toJsonTree(results).getAsJsonObject();
     MessageBuilder messageBuilder = new MessageBuilder();
+    messageBuilder.setQoS(qos).storeOffline(storeOffline);
+    sendMessage(
+        statusTopic,
+        messageBuilder
+            .setContentType("application/json")
+            .setOpaqueData(resultsJson.toString().getBytes(StandardCharsets.UTF_8))
+            .build());
+  }
+
+  private void publishRejectedFrame(ProcessedFrame env, byte[] raw) {
+    String namespace = mavlinkConfig.getRejectedFrameNamespace();
+    if (namespace == null || namespace.isEmpty()) {
+      return;
+    }
+
+    MessageBuilder messageBuilder = new MessageBuilder();
+    messageBuilder.setQoS(qos).storeOffline(storeOffline);
+    if (mavlinkConfig.isIncludeRejectedFrameMetadata()) {
+      JsonObject metadata = new JsonObject();
+      metadata.addProperty("messageName", env.getMessageName());
+      metadata.addProperty("messageId", env.getFrame().getMessageId());
+      metadata.addProperty("systemId", env.getFrame().getSystemId());
+      metadata.addProperty("componentId", env.getFrame().getComponentId());
+      metadata.addProperty(
+          "payload", Base64.getEncoder().encodeToString(env.getFrame().getPayload()));
+      metadata.addProperty("sequence", env.getFrame().getSequence());
+      metadata.addProperty("signed", env.getFrame().isSigned());
+      metadata.addProperty("time_ms", System.currentTimeMillis());
+      messageBuilder.setOpaqueData(metadata.toString().getBytes(StandardCharsets.UTF_8));
+    } else {
+      messageBuilder.setOpaqueData(raw);
+    }
+
+    String topicName = computeTopicName(namespace, env.getFrame(), env.getMessageName());
+    sendMessage(topicName, messageBuilder.build());
+  }
+
+  public boolean processPacket(
+      @NonNull @NotNull Frame envelope,
+      String messageName,
+      byte[] raw,
+      String socketAddress) {
     Map<String, String> metaData = new HashMap<>();
     metaData.put("protocol", "MavLink");
-    metaData.put("version", "" + envelope.getVersion());
+    metaData.put("version", envelope.getVersion().toString());
     metaData.put("sessionId", session.getName());
-    metaData.put("time_ms", "" + System.currentTimeMillis());
+    metaData.put("time_ms", Long.toString(System.currentTimeMillis()));
 
     Message message =
-        messageBuilder
+        new MessageBuilder()
             .setContentType("mavlink")
             .setOpaqueData(raw)
             .setDataMap(convertToMap(envelope))
@@ -345,13 +422,15 @@ public class MavlinkProtocol extends Protocol {
             .setMeta(metaData)
             .build();
 
-    String topicName = computeTopicName(mavlinkConfig.getTopicNameTemplate(), envelope, messageName);
+    String topicName =
+        computeTopicName(mavlinkConfig.getTopicNameTemplate(), envelope, messageName);
     sendMessage(topicName, message);
     return true;
   }
 
   private void sendMessage(String topicName, Message message) {
-    CompletableFuture<Destination> future = session.findDestination(topicName, DestinationType.TOPIC);
+    CompletableFuture<Destination> future =
+        session.findDestination(topicName, DestinationType.TOPIC);
     if (future == null) {
       logger.log(MAVLINK_DESTINATION_NOT_AVAILABLE, topicName);
       return;
@@ -379,10 +458,7 @@ public class MavlinkProtocol extends Protocol {
 
   @Override
   public String getSessionId() {
-    if (session != null) {
-      return session.getName();
-    }
-    return "waiting";
+    return session != null ? session.getName() : "waiting";
   }
 
   @Override
@@ -392,10 +468,10 @@ public class MavlinkProtocol extends Protocol {
 
   protected String computeTopicName(String template, Frame envelope, String messageName) {
     template = template.replace("{remoteSocket}", getRemoteSocket());
-    template = template.replace("{systemName}", "" + envelope.getSystemId());
-    template = template.replace("{systemId}", "" + envelope.getSystemId());
-    template = template.replace("{componentId}", "" + envelope.getComponentId());
-    template = template.replace("{messageId}", "" + envelope.getMessageId());
+    template = template.replace("{systemName}", Integer.toString(envelope.getSystemId()));
+    template = template.replace("{systemId}", Integer.toString(envelope.getSystemId()));
+    template = template.replace("{componentId}", Integer.toString(envelope.getComponentId()));
+    template = template.replace("{messageId}", Integer.toString(envelope.getMessageId()));
     template = template.replace("{messageName}", messageName);
     return template;
   }
@@ -415,12 +491,17 @@ public class MavlinkProtocol extends Protocol {
     return map;
   }
 
-  public boolean allowMessageId(int componentId, int messageId){
-    if(acceptedComponents == null || acceptedComponents.isEmpty()) return true;
+  public boolean allowMessageId(int componentId, int messageId) {
+    if (acceptedComponents == null || acceptedComponents.isEmpty()) {
+      return true;
+    }
     MavlinkAcceptedSourceDTO knownSource = acceptedComponents.get(componentId);
-    if(knownSource == null) return false;
-    if(knownSource.getAcceptedMessageIds().isEmpty()){
-      return mavlinkConfig.getAcceptedMessageIds().isEmpty() || mavlinkConfig.getAcceptedMessageIds().contains(messageId);
+    if (knownSource == null) {
+      return false;
+    }
+    if (knownSource.getAcceptedMessageIds().isEmpty()) {
+      return mavlinkConfig.getAcceptedMessageIds().isEmpty()
+          || mavlinkConfig.getAcceptedMessageIds().contains(messageId);
     }
     return knownSource.getAcceptedMessageIds().contains(messageId);
   }
@@ -431,15 +512,14 @@ public class MavlinkProtocol extends Protocol {
     }
 
     String trimmedSocketAddress = socketAddressText.trim();
-
     int portSeparatorIndex = trimmedSocketAddress.lastIndexOf(':');
     if (portSeparatorIndex < 0 || portSeparatorIndex == trimmedSocketAddress.length() - 1) {
-      throw new IllegalArgumentException("Socket address must include a port: " + socketAddressText);
+      throw new IllegalArgumentException(
+          "Socket address must include a port: " + socketAddressText);
     }
 
     String hostPart = trimmedSocketAddress.substring(0, portSeparatorIndex);
     String portPart = trimmedSocketAddress.substring(portSeparatorIndex + 1);
-
     if (hostPart.startsWith("/")) {
       hostPart = hostPart.substring(1);
     }
@@ -448,30 +528,30 @@ public class MavlinkProtocol extends Protocol {
     if (slashIndex >= 0) {
       hostPart = hostPart.substring(0, slashIndex);
     }
-
     if (hostPart.isBlank()) {
       throw new IllegalArgumentException("Socket address must include a host: " + socketAddressText);
     }
 
-    int port = Integer.parseInt(portPart);
-
-    return new InetSocketAddress(hostPart, port);
+    return new InetSocketAddress(hostPart, Integer.parseInt(portPart));
   }
 
-
   private void startHeartbeatIfConfigured() {
-    if (!mavlinkConfig.hasLocalMavlinkIdentity()) {
+    if (heartbeatEmitter == null || heartbeatFuture != null) {
       return;
     }
 
     long intervalSeconds = Math.max(1, mavlinkConfig.getHeartbeatIntervalSeconds());
-    SimpleTaskScheduler.getInstance().scheduleAtFixedRate(heartbeatEmitter, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+    heartbeatFuture =
+        SimpleTaskScheduler.getInstance()
+            .scheduleAtFixedRate(
+                heartbeatEmitter, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
   }
 
   private void stopHeartbeat() {
-    if (heartbeatFuture != null) {
-      heartbeatFuture.cancel(false);
-      heartbeatFuture = null;
+    ScheduledFuture<?> future = heartbeatFuture;
+    heartbeatFuture = null;
+    if (future != null) {
+      future.cancel(false);
     }
   }
 
@@ -492,6 +572,7 @@ public class MavlinkProtocol extends Protocol {
   public int nextSequence() {
     return sequenceCounter.getAndUpdate(value -> (value + 1) & 0xff);
   }
+
   private void validateOutboundHeader(JsonObject input) {
     JsonObject header = input.getAsJsonObject("header");
     if (header == null) {
@@ -500,9 +581,9 @@ public class MavlinkProtocol extends Protocol {
 
     int systemId = getRequiredUnsignedByte(header, "systemId");
     int componentId = getRequiredUnsignedByte(header, "componentId");
-
     if (systemId == 0 || componentId == 0) {
-      throw new IllegalArgumentException("Invalid MAVLink sender identity " + systemId + "/" + componentId);
+      throw new IllegalArgumentException(
+          "Invalid MAVLink sender identity " + systemId + "/" + componentId);
     }
   }
 
@@ -513,9 +594,9 @@ public class MavlinkProtocol extends Protocol {
 
     int value = object.get(fieldName).getAsInt();
     if (value < 0 || value > 255) {
-      throw new IllegalArgumentException("Invalid MAVLink header field '" + fieldName + "': " + value);
+      throw new IllegalArgumentException(
+          "Invalid MAVLink header field '" + fieldName + "': " + value);
     }
-
     return value;
   }
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkProtocolFactory.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkProtocolFactory.java
@@ -19,6 +19,8 @@
 
 package io.mapsmessaging.network.protocol.impl.mavlink;
 
+import static io.mapsmessaging.logging.ServerLogMessages.MAVLINK_FAILED_SETTING_UP_SESSION;
+
 import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.network.io.EndPoint;
@@ -27,14 +29,10 @@ import io.mapsmessaging.network.io.Packet;
 import io.mapsmessaging.network.io.impl.NetworkInfoHelper;
 import io.mapsmessaging.network.protocol.Protocol;
 import io.mapsmessaging.network.protocol.ProtocolImplFactory;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static io.mapsmessaging.logging.ServerLogMessages.MAVLINK_FAILED_SETTING_UP_SESSION;
-
-// The protocol is Mavlink so it makes sense
 @SuppressWarnings("squid:S00101")
 public class MavlinkProtocolFactory extends ProtocolImplFactory {
 
@@ -52,16 +50,22 @@ public class MavlinkProtocolFactory extends ProtocolImplFactory {
   }
 
   @Override
-  public Protocol connect(EndPoint endPoint, String sessionId, String username, String password, Map<String, String> topicMap) throws IOException {
+  public Protocol connect(
+      EndPoint endPoint,
+      String sessionId,
+      String username,
+      String password,
+      Map<String, String> topicMap)
+      throws IOException {
     return null;
   }
 
   @Override
   public void create(EndPoint endPoint, Packet packet) {
     try {
-      new MavlinkSerialProtocol(endPoint, endPoint.getConfig().getProtocolConfig("mavlink"));
-
-    } catch (IOException e) {
+      new MavlinkSerialProtocol(
+          endPoint, endPoint.getConfig().getProtocolConfig("mavlink"));
+    } catch (IOException | RuntimeException e) {
       logger.log(MAVLINK_FAILED_SETTING_UP_SESSION, endPoint.getName(), e);
     }
   }
@@ -87,8 +91,8 @@ public class MavlinkProtocolFactory extends ProtocolImplFactory {
   }
 
   public void close() {
-    for (MavlinkInterfaceManager managers : mappedInterfaces.values()) {
-      managers.close();
+    for (MavlinkInterfaceManager manager : mappedInterfaces.values()) {
+      manager.close();
     }
     mappedInterfaces.clear();
   }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkStreamHandler.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkStreamHandler.java
@@ -35,7 +35,7 @@ public class MavlinkStreamHandler implements StreamHandler {
   private static final int MAVLINK_V1_MAGIC = 0xFE;
   private static final int MAVLINK_V2_MAGIC = 0xFD;
 
-  private static final int MAVLINK_V1_HEADER_REST = 5;
+  private static final int MAVLINK_V1_HEADER_REST = 4;
   private static final int MAVLINK_V1_CRC_LEN = 2;
 
   private static final int MAVLINK_V2_HEADER_REST = 8;

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkStreamHandler.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkStreamHandler.java
@@ -35,15 +35,16 @@ public class MavlinkStreamHandler implements StreamHandler {
   private static final int MAVLINK_V1_MAGIC = 0xFE;
   private static final int MAVLINK_V2_MAGIC = 0xFD;
 
-  private static final int MAVLINK_V1_HEADER_REST = 5; // after magic+len
+  private static final int MAVLINK_V1_HEADER_REST = 5;
   private static final int MAVLINK_V1_CRC_LEN = 2;
 
-  private static final int MAVLINK_V2_HEADER_REST = 8; // after magic+len (incompat, compat, seq, sys, comp, msgid[3])
+  private static final int MAVLINK_V2_HEADER_REST = 8;
   private static final int MAVLINK_V2_CRC_LEN = 2;
   private static final int MAVLINK_V2_SIGNATURE_LEN = 13;
   private static final int MAVLINK_V2_INCOMPAT_FLAG_SIGNED = 0x01;
 
-  private final byte[] smallBuffer;
+  private final byte[] inputBuffer;
+  private final byte[] outputBuffer;
   private final int readTimeoutMillis;
 
   private volatile boolean closed;
@@ -51,15 +52,16 @@ public class MavlinkStreamHandler implements StreamHandler {
   public MavlinkStreamHandler() {
     this(DEFAULT_READ_TIMEOUT_MILLIS);
   }
+
   public MavlinkStreamHandler(int readTimeoutMillis) {
-    this.smallBuffer = new byte[32];
-    this.closed = false;
+    inputBuffer = new byte[32];
+    outputBuffer = new byte[32];
+    closed = false;
     if (readTimeoutMillis <= 0) {
       throw new IllegalArgumentException("readTimeoutMillis must be > 0");
     }
     this.readTimeoutMillis = readTimeoutMillis;
   }
-
 
   @Override
   public void close() {
@@ -106,19 +108,19 @@ public class MavlinkStreamHandler implements StreamHandler {
       packet.putByte(magic);
       packet.putByte(payloadLength);
 
-      readFully(input, smallBuffer, 0, MAVLINK_V1_HEADER_REST);
-      packet.put(smallBuffer, 0, MAVLINK_V1_HEADER_REST);
+      readFully(input, inputBuffer, 0, MAVLINK_V1_HEADER_REST);
+      packet.put(inputBuffer, 0, MAVLINK_V1_HEADER_REST);
 
       readPayload(input, packet, payloadLength);
 
-      readFully(input, smallBuffer, 0, MAVLINK_V1_CRC_LEN);
-      packet.put(smallBuffer, 0, MAVLINK_V1_CRC_LEN);
+      readFully(input, inputBuffer, 0, MAVLINK_V1_CRC_LEN);
+      packet.put(inputBuffer, 0, MAVLINK_V1_CRC_LEN);
       return frameLength;
     }
 
-    readFully(input, smallBuffer, 0, MAVLINK_V2_HEADER_REST);
+    readFully(input, inputBuffer, 0, MAVLINK_V2_HEADER_REST);
 
-    int incompatFlags = smallBuffer[0] & 0xFF;
+    int incompatFlags = inputBuffer[0] & 0xFF;
     boolean signed = (incompatFlags & MAVLINK_V2_INCOMPAT_FLAG_SIGNED) != 0;
 
     int frameLength = 2 + MAVLINK_V2_HEADER_REST + payloadLength + MAVLINK_V2_CRC_LEN + (signed ? MAVLINK_V2_SIGNATURE_LEN : 0);
@@ -126,17 +128,16 @@ public class MavlinkStreamHandler implements StreamHandler {
 
     packet.putByte(magic);
     packet.putByte(payloadLength);
-
-    packet.put(smallBuffer, 0, MAVLINK_V2_HEADER_REST);
+    packet.put(inputBuffer, 0, MAVLINK_V2_HEADER_REST);
 
     readPayload(input, packet, payloadLength);
 
-    readFully(input, smallBuffer, 0, MAVLINK_V2_CRC_LEN);
-    packet.put(smallBuffer, 0, MAVLINK_V2_CRC_LEN);
+    readFully(input, inputBuffer, 0, MAVLINK_V2_CRC_LEN);
+    packet.put(inputBuffer, 0, MAVLINK_V2_CRC_LEN);
 
     if (signed) {
-      readFully(input, smallBuffer, 0, MAVLINK_V2_SIGNATURE_LEN);
-      packet.put(smallBuffer, 0, MAVLINK_V2_SIGNATURE_LEN);
+      readFully(input, inputBuffer, 0, MAVLINK_V2_SIGNATURE_LEN);
+      packet.put(inputBuffer, 0, MAVLINK_V2_SIGNATURE_LEN);
     }
     return frameLength;
   }
@@ -154,7 +155,6 @@ public class MavlinkStreamHandler implements StreamHandler {
     }
 
     ByteBuffer buffer = packet.getRawBuffer().duplicate();
-
     int position = buffer.position();
     int limit = buffer.limit();
 
@@ -168,9 +168,9 @@ public class MavlinkStreamHandler implements StreamHandler {
     }
 
     while (buffer.hasRemaining()) {
-      int chunk = Math.min(buffer.remaining(), smallBuffer.length);
-      buffer.get(smallBuffer, 0, chunk);
-      output.write(smallBuffer, 0, chunk);
+      int chunk = Math.min(buffer.remaining(), outputBuffer.length);
+      buffer.get(outputBuffer, 0, chunk);
+      output.write(outputBuffer, 0, chunk);
     }
 
     return length;
@@ -183,14 +183,11 @@ public class MavlinkStreamHandler implements StreamHandler {
   }
 
   private void readPayload(InputStream input, Packet packet, int payloadLength) throws IOException {
-    if (payloadLength == 0) {
-      return;
-    }
     int remaining = payloadLength;
     while (remaining > 0) {
-      int chunk = Math.min(remaining, smallBuffer.length);
-      readFully(input, smallBuffer, 0, chunk);
-      packet.put(smallBuffer, 0, chunk);
+      int chunk = Math.min(remaining, inputBuffer.length);
+      readFully(input, inputBuffer, 0, chunk);
+      packet.put(inputBuffer, 0, chunk);
       remaining -= chunk;
     }
   }
@@ -205,7 +202,6 @@ public class MavlinkStreamHandler implements StreamHandler {
       }
 
       int read = input.read(buffer, offset + readTotal, length - readTotal);
-
       if (read < 0) {
         throw new IOException("Unexpected end of stream");
       }

--- a/src/main/java/io/mapsmessaging/state/mavlink/MavlinkStateSubscriber.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/MavlinkStateSubscriber.java
@@ -19,7 +19,10 @@
 
 package io.mapsmessaging.state.mavlink;
 
+import static io.mapsmessaging.state.logging.StateLogMessages.*;
+
 import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.mapsmessaging.api.MessageEvent;
@@ -44,9 +47,6 @@ import io.mapsmessaging.state.mavlink.listener.ListenerManager;
 import io.mapsmessaging.state.mavlink.packet.MavlinkPacket;
 import io.mapsmessaging.state.mavlink.packet.MavlinkPacketFactory;
 import io.mapsmessaging.state.util.SessionHelper;
-import lombok.NonNull;
-import org.jetbrains.annotations.NotNull;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -54,8 +54,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
-
-import static io.mapsmessaging.state.logging.StateLogMessages.*;
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 public class MavlinkStateSubscriber implements MessageHandler {
 
@@ -66,13 +66,18 @@ public class MavlinkStateSubscriber implements MessageHandler {
   private final MavlinkSourceRegistry sourceRegistry;
   private final DroneInfoRegistry droneRegistry;
   private final MavlinkTwinUpdater twinUpdater;
+  private final Gson gson;
 
-  public MavlinkStateSubscriber(@NonNull @NotNull TwinManager twinManager, @NonNull @NotNull MavlinkTwinConfigDTO mavlinkConfig, @NonNull @NotNull DroneInfoRegistry registry) {
-    this.protocol = SessionHelper.createLoopbackProtocol(this);
-    this.namespaceTopicPath = mavlinkConfig.getTopic();
-    this.sourceRegistry = new MavlinkSourceRegistry(mavlinkConfig);
-    this.droneRegistry = registry;
-    this.twinUpdater = new MavlinkTwinUpdater(twinManager, new ListenerManager(twinManager));
+  public MavlinkStateSubscriber(
+      @NonNull @NotNull TwinManager twinManager,
+      @NonNull @NotNull MavlinkTwinConfigDTO mavlinkConfig,
+      @NonNull @NotNull DroneInfoRegistry registry) {
+    protocol = SessionHelper.createLoopbackProtocol(this);
+    namespaceTopicPath = mavlinkConfig.getTopic();
+    sourceRegistry = new MavlinkSourceRegistry(mavlinkConfig);
+    droneRegistry = registry;
+    twinUpdater = new MavlinkTwinUpdater(twinManager, new ListenerManager(twinManager));
+    gson = GsonFactory.createStrictJsonWithSafeFloats();
   }
 
   public void start() throws IOException {
@@ -80,9 +85,18 @@ public class MavlinkStateSubscriber implements MessageHandler {
 
     try {
       protocol.connect(UUID.randomUUID().toString(), "anonymous", "anonymous");
-      protocol.subscribeLocal(namespaceTopicPath, namespaceTopicPath, QualityOfService.AT_MOST_ONCE, null, null, null, null, null);
+      protocol.subscribeLocal(
+          namespaceTopicPath,
+          namespaceTopicPath,
+          QualityOfService.AT_MOST_ONCE,
+          null,
+          null,
+          null,
+          null,
+          null);
       logger.log(MAVLINK_STATE_SUBSCRIBER_STARTED, namespaceTopicPath);
     } catch (IOException exception) {
+      closeAfterStartFailure(exception);
       logger.log(MAVLINK_STATE_SUBSCRIBER_START_FAILED, exception, namespaceTopicPath);
       throw exception;
     }
@@ -91,14 +105,30 @@ public class MavlinkStateSubscriber implements MessageHandler {
   public void stop() throws IOException {
     logger.log(MAVLINK_STATE_SUBSCRIBER_STOPPING, namespaceTopicPath);
 
+    IOException failure = null;
     try {
       protocol.unsubscribeLocal(namespaceTopicPath);
-      protocol.close();
-      logger.log(MAVLINK_STATE_SUBSCRIBER_STOPPED, namespaceTopicPath);
     } catch (IOException exception) {
-      logger.log(MAVLINK_STATE_SUBSCRIBER_STOP_FAILED, exception, namespaceTopicPath);
-      throw exception;
+      failure = exception;
     }
+
+    try {
+      protocol.close();
+    } catch (IOException exception) {
+      if (failure == null) {
+        failure = exception;
+      } else {
+        failure.addSuppressed(exception);
+      }
+    } finally {
+      twinUpdater.close();
+    }
+
+    if (failure != null) {
+      logger.log(MAVLINK_STATE_SUBSCRIBER_STOP_FAILED, failure, namespaceTopicPath);
+      throw failure;
+    }
+    logger.log(MAVLINK_STATE_SUBSCRIBER_STOPPED, namespaceTopicPath);
   }
 
   @Override
@@ -111,7 +141,6 @@ public class MavlinkStateSubscriber implements MessageHandler {
     try {
       Message message = messageEvent.getMessage();
       ProcessedFrame env = parseJson(message.getOpaqueData(), sourceName);
-
       if (env == null) {
         return;
       }
@@ -127,13 +156,16 @@ public class MavlinkStateSubscriber implements MessageHandler {
 
       MavlinkKnownSourceDTO knownSource = sourceRegistry.getKnownSource(env);
       if (knownSource == null) {
-        logger.log(MAVLINK_STATE_SOURCE_NOT_CONFIGURED, messageId, frame.getSystemId(), frame.getComponentId());
+        logger.log(
+            MAVLINK_STATE_SOURCE_NOT_CONFIGURED,
+            messageId,
+            frame.getSystemId(),
+            frame.getComponentId());
         return;
       }
 
       droneName = knownSource.getName();
       DroneInfoDTO droneInfo = droneRegistry.getDroneInfo(droneName);
-
       if (droneInfo == null) {
         logger.log(MAVLINK_STATE_DRONE_NOT_CONFIGURED, messageId, sourceName, droneName);
         return;
@@ -141,32 +173,49 @@ public class MavlinkStateSubscriber implements MessageHandler {
 
       TwinUpdateContext context = buildUpdateContext(env, message.getResponseTopic());
       byte[] correlationData = message.getCorrelationData();
-
       if (correlationData == null || correlationData.length == 0) {
         logger.log(MAVLINK_STATE_CORRELATION_DATA_MISSING, messageId, sourceName);
       } else {
-        context.setUniqueOutboundIdentifier(new String(correlationData, StandardCharsets.UTF_8));
+        context.setUniqueOutboundIdentifier(
+            new String(correlationData, StandardCharsets.UTF_8));
       }
 
       updatingTwin = true;
       twinUpdater.updateTwinState(env, packet, context, knownSource, droneInfo);
     } catch (RuntimeException exception) {
       if (updatingTwin) {
-        logger.log(MAVLINK_STATE_TWIN_UPDATE_FAILED, exception, droneName, messageId, sourceName);
+        logger.log(
+            MAVLINK_STATE_TWIN_UPDATE_FAILED,
+            exception,
+            droneName,
+            messageId,
+            sourceName);
       } else {
         logger.log(MAVLINK_STATE_PROCESSING_FAILED, exception, sourceName);
       }
-
-      throw exception;
     } finally {
       messageEvent.getCompletionTask().run();
+    }
+  }
+
+  private void closeAfterStartFailure(IOException original) {
+    try {
+      protocol.close();
+    } catch (IOException closeException) {
+      original.addSuppressed(closeException);
+    } finally {
+      twinUpdater.close();
     }
   }
 
   private TwinUpdateContext buildUpdateContext(ProcessedFrame env, String responseTopic) {
     TwinUpdateContext context = new TwinUpdateContext();
     context.setUpdateSource("mavlink");
-    context.setSourceInstanceId("mavlink:" + env.getFrame().getSystemId() + ":" + env.getFrame().getComponentId());
+    context.setSourceInstanceId(
+        "mavlink:"
+            + env.getFrame().getSystemId()
+            + ":"
+            + env.getFrame().getComponentId());
     context.setReceivedTime(Instant.now());
     context.setSequenceNumber((long) env.getFrame().getSequence());
     context.setReason(env.getMessageName());
@@ -182,17 +231,20 @@ public class MavlinkStateSubscriber implements MessageHandler {
     }
 
     try {
-      JsonObject jsonObject = JsonParser.parseString(new String(opaqueData, StandardCharsets.UTF_8)).getAsJsonObject();
+      JsonObject jsonObject =
+          JsonParser.parseString(new String(opaqueData, StandardCharsets.UTF_8))
+              .getAsJsonObject();
       JsonObject mavlinkObject = jsonObject.getAsJsonObject("mavlink");
-
       if (mavlinkObject == null) {
         logger.log(MAVLINK_STATE_MAVLINK_OBJECT_MISSING, sourceName);
         return null;
       }
 
-      Object messageId = mavlinkObject.has("messageId") && !mavlinkObject.get("messageId").isJsonNull() ? mavlinkObject.get("messageId").getAsInt() : "unknown";
+      Object messageId =
+          mavlinkObject.has("messageId") && !mavlinkObject.get("messageId").isJsonNull()
+              ? mavlinkObject.get("messageId").getAsInt()
+              : "unknown";
       JsonObject payloadObject = mavlinkObject.getAsJsonObject("payload");
-
       if (payloadObject == null) {
         logger.log(MAVLINK_STATE_PAYLOAD_OBJECT_MISSING, messageId, sourceName);
         return null;
@@ -213,12 +265,20 @@ public class MavlinkStateSubscriber implements MessageHandler {
       frame.setSignature(null);
 
       Map<String, Object> fields = new LinkedHashMap<>();
-
       if (payloadObject.has("decoded") && payloadObject.get("decoded").isJsonObject()) {
-        fields = GsonFactory.createStrictJsonWithSafeFloats().fromJson(payloadObject.getAsJsonObject("decoded"), new TypeToken<LinkedHashMap<String, Object>>() {}.getType());
+        fields =
+            gson.fromJson(
+                payloadObject.getAsJsonObject("decoded"),
+                new TypeToken<LinkedHashMap<String, Object>>() {}.getType());
       }
 
-      return new ProcessedFrame(Integer.toString(frame.getMessageId()), frame, fields, true, Collections.emptyList(), null);
+      return new ProcessedFrame(
+          Integer.toString(frame.getMessageId()),
+          frame,
+          fields,
+          true,
+          Collections.emptyList(),
+          null);
     } catch (RuntimeException exception) {
       logger.log(MAVLINK_STATE_JSON_PARSE_FAILED, exception, sourceName);
       return null;

--- a/src/main/java/io/mapsmessaging/state/mavlink/MavlinkTwinUpdater.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/MavlinkTwinUpdater.java
@@ -48,7 +48,7 @@ import java.util.Optional;
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
 
-public class MavlinkTwinUpdater {
+public class MavlinkTwinUpdater implements AutoCloseable {
 
   private final Logger logger = LoggerFactory.getLogger(MavlinkTwinUpdater.class);
 
@@ -56,16 +56,31 @@ public class MavlinkTwinUpdater {
   private final ListenerManager listenerManager;
   private final MavlinkDroneMonitor droneMonitor;
 
-  public MavlinkTwinUpdater(@NonNull @NotNull TwinManager twinManager, @NonNull @NotNull ListenerManager listenerManager) {
+  public MavlinkTwinUpdater(
+      @NonNull @NotNull TwinManager twinManager,
+      @NonNull @NotNull ListenerManager listenerManager) {
     this.twinManager = twinManager;
     this.listenerManager = listenerManager;
-    this.droneMonitor = new MavlinkDroneMonitor(twinManager, new DroneTwinReadinessEvaluator(), new MavlinkBootstrapStateEngine(new MavlinkBootstrapProfile()), null);
+    droneMonitor =
+        new MavlinkDroneMonitor(
+            twinManager,
+            new DroneTwinReadinessEvaluator(),
+            new MavlinkBootstrapStateEngine(new MavlinkBootstrapProfile()),
+            null);
     twinManager.addObserver(droneMonitor);
   }
 
-  public void updateTwinState(@NonNull @NotNull ProcessedFrame env, @NonNull @NotNull MavlinkPacket packet, @NonNull @NotNull TwinUpdateContext context, @NonNull @NotNull MavlinkKnownSourceDTO knownSource, DroneInfoDTO droneInfo) {
+  public void updateTwinState(
+      @NonNull @NotNull ProcessedFrame env,
+      @NonNull @NotNull MavlinkPacket packet,
+      @NonNull @NotNull TwinUpdateContext context,
+      @NonNull @NotNull MavlinkKnownSourceDTO knownSource,
+      DroneInfoDTO droneInfo) {
     String twinId = buildTwinId(env, knownSource);
-    EntityTwin entityTwin = twinManager.getTwin(twinId).orElseGet(() -> createTwin(twinId, env, context, knownSource, droneInfo));
+    EntityTwin entityTwin =
+        twinManager
+            .getTwin(twinId)
+            .orElseGet(() -> createTwin(twinId, env, context, knownSource, droneInfo));
     twinManager.updateTwin(
         twinId,
         twinToUpdate -> {
@@ -76,18 +91,22 @@ public class MavlinkTwinUpdater {
             drone.setUniqueOutboundIdentifier(context.getUniqueOutboundIdentifier());
           }
         },
-        context
-    );
+        context);
 
     listenerManager.handle(env.getFrame().getMessageId(), twinId, packet, context);
 
     if (entityTwin instanceof DroneTwin droneTwin) {
       MavlinkEventListSender sender = droneTwin.getActiveMavlinkSender();
-      if(sender != null){
+      if (sender != null) {
         sender.onMavlinkMessage(packet);
       }
       applyModelDetectionEvent(droneTwin, packet);
     }
+  }
+
+  @Override
+  public void close() {
+    twinManager.removeObserver(droneMonitor);
   }
 
   private void applyModelDetectionEvent(DroneTwin droneTwin, MavlinkPacket packet) {
@@ -98,12 +117,10 @@ public class MavlinkTwinUpdater {
 
     try {
       UxvModel uxvModel = ModelManager.getInstance().getRequiredModel(modelName);
-      if(uxvModel != null) {
-        Optional<DetectionEvent> detectionEvent = uxvModel.interpretDetection(droneTwin, packet);
-        detectionEvent.ifPresent(event -> applyDetectionEvent(droneTwin, event));
-      }
-    } catch (IllegalArgumentException e) {
-      // no such model, ignore
+      Optional<DetectionEvent> detectionEvent = uxvModel.interpretDetection(droneTwin, packet);
+      detectionEvent.ifPresent(event -> applyDetectionEvent(droneTwin, event));
+    } catch (IllegalArgumentException ignored) {
+      // Unknown models do not contribute detection events.
     }
   }
 
@@ -124,7 +141,6 @@ public class MavlinkTwinUpdater {
     }
 
     DroneContactManager contactManager = droneTwin.getContactManager();
-
     switch (event.getEventType()) {
       case DETECTED, UPDATED -> upsertContact(contactManager, event);
       case LOST -> removeContact(contactManager, event);
@@ -143,13 +159,15 @@ public class MavlinkTwinUpdater {
 
     GeoPosition position = event.getPosition();
     String name = event.getName();
-
     if (contactManager.hasContact(event.getContactId())) {
       contactManager.updateContact(event.getContactId(), name, position, ttlMillis);
-    } else {
-      Contact contact = new Contact(name, position, ttlMillis);
-      contactManager.addContact(contact);
+      return;
     }
+
+    long now = System.currentTimeMillis();
+    Contact contact =
+        new Contact(event.getContactId(), name, position, ttlMillis, now, now);
+    contactManager.addContact(contact);
   }
 
   private void removeContact(DroneContactManager contactManager, DetectionEvent event) {
@@ -158,22 +176,23 @@ public class MavlinkTwinUpdater {
     }
   }
 
-  private EntityTwin createTwin(String twinId, ProcessedFrame env, TwinUpdateContext context, MavlinkKnownSourceDTO knownSource, DroneInfoDTO droneInfo) {
+  private EntityTwin createTwin(
+      String twinId,
+      ProcessedFrame env,
+      TwinUpdateContext context,
+      MavlinkKnownSourceDTO knownSource,
+      DroneInfoDTO droneInfo) {
     DroneTwin droneTwin = new DroneTwin(twinId, droneInfo.getUuid());
     droneTwin.setVehicleClass(resolveVehicleClass(knownSource));
-    droneTwin.setDescriptionString(resolveDescription(twinId, env, knownSource));
+    droneTwin.setDescriptionString(resolveDescription(env, knownSource));
     droneTwin.setCallSign(resolveCallSign(twinId, knownSource));
     droneTwin.setDisplayName(resolveDisplayName(twinId, knownSource));
     droneTwin.setSystemId(env.getFrame().getSystemId());
     droneTwin.setComponentId(env.getFrame().getComponentId());
     droneTwin.setModelName(droneInfo.getModelName());
     droneTwin.setSurveyRadiusMeters(droneInfo.getSurveyRadiusMeters());
-    if(droneInfo.getStopAction() != null) {
-      droneTwin.setStopAction(droneInfo.getStopAction());
-    }
-    else{
-      droneTwin.setStopAction(StopActionEnum.STOP);
-    }
+    droneTwin.setStopAction(
+        droneInfo.getStopAction() != null ? droneInfo.getStopAction() : StopActionEnum.STOP);
     if (droneInfo.getCapabilities() != null) {
       droneTwin.setCapabilities(droneInfo.getCapabilities());
       droneTwin.setDescription(droneInfo.getDescription());
@@ -181,19 +200,14 @@ public class MavlinkTwinUpdater {
 
     if (droneInfo.getBatteryCapacityHours() > 0) {
       droneTwin.setBatteryCapacityHours(droneInfo.getBatteryCapacityHours());
-    } else if (droneInfo.getBatteryCapacityAh() > 0) {
-
     }
 
     twinManager.registerTwin(droneTwin, context);
-
     logger.log(
         MAVLINK_STATE_TWIN_CREATED,
         twinId,
         env.getFrame().getSystemId(),
-        env.getFrame().getComponentId()
-    );
-
+        env.getFrame().getComponentId());
     return droneTwin;
   }
 
@@ -201,51 +215,52 @@ public class MavlinkTwinUpdater {
     if (knownSource == null || knownSource.getVehicleClass() == null) {
       return VehicleClass.UAV;
     }
-
     return knownSource.getVehicleClass();
   }
 
   private String resolveDescription(
-      String twinId,
-      ProcessedFrame env,
-      MavlinkKnownSourceDTO knownSource
-  ) {
-    if (knownSource != null && knownSource.getDescription() != null && !knownSource.getDescription().isBlank()) {
+      ProcessedFrame env, MavlinkKnownSourceDTO knownSource) {
+    if (knownSource != null
+        && knownSource.getDescription() != null
+        && !knownSource.getDescription().isBlank()) {
       return knownSource.getDescription();
     }
 
-    return "MAVLink system " + env.getFrame().getSystemId() + " component " + env.getFrame().getComponentId();
+    return "MAVLink system "
+        + env.getFrame().getSystemId()
+        + " component "
+        + env.getFrame().getComponentId();
   }
 
   private String resolveCallSign(String twinId, MavlinkKnownSourceDTO knownSource) {
-    if (knownSource != null && knownSource.getName() != null && !knownSource.getName().isBlank()) {
+    if (knownSource != null
+        && knownSource.getName() != null
+        && !knownSource.getName().isBlank()) {
       return knownSource.getName();
     }
-
-    if (twinId.length() > 7) {
-      return twinId.substring(twinId.length() - 7);
-    }
-
-    return twinId;
+    return twinId.length() > 7 ? twinId.substring(twinId.length() - 7) : twinId;
   }
 
   private String resolveDisplayName(String twinId, MavlinkKnownSourceDTO knownSource) {
-    if (knownSource != null && knownSource.getDescription() != null && !knownSource.getDescription().isBlank()) {
+    if (knownSource != null
+        && knownSource.getDescription() != null
+        && !knownSource.getDescription().isBlank()) {
       return knownSource.getDescription();
     }
-
-    if (knownSource != null && knownSource.getName() != null && !knownSource.getName().isBlank()) {
+    if (knownSource != null
+        && knownSource.getName() != null
+        && !knownSource.getName().isBlank()) {
       return knownSource.getName();
     }
-
     return twinId;
   }
 
   private String buildTwinId(ProcessedFrame env, MavlinkKnownSourceDTO knownSource) {
-    if (knownSource != null && knownSource.getName() != null && !knownSource.getName().isBlank()) {
+    if (knownSource != null
+        && knownSource.getName() != null
+        && !knownSource.getName().isBlank()) {
       return knownSource.getName();
     }
-
     return "mavlink-" + env.getFrame().getSystemId() + ":" + env.getFrame().getComponentId();
   }
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/packet/MavlinkPacket.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/packet/MavlinkPacket.java
@@ -19,6 +19,7 @@
 
 package io.mapsmessaging.state.mavlink.packet;
 
+import java.util.List;
 import java.util.Map;
 
 public abstract class MavlinkPacket {
@@ -45,6 +46,18 @@ public abstract class MavlinkPacket {
       int[] result = new int[data.length];
       for (int index = 0; index < data.length; index++) {
         result[index] = data[index] & 0xFF;
+      }
+      return result;
+    }
+
+    if (value instanceof List<?> data) {
+      int[] result = new int[data.size()];
+      for (int index = 0; index < data.size(); index++) {
+        Object entry = data.get(index);
+        if (!(entry instanceof Number number)) {
+          return new int[0];
+        }
+        result[index] = number.intValue();
       }
       return result;
     }
@@ -85,7 +98,6 @@ public abstract class MavlinkPacket {
 
     return raw / 100.0;
   }
-
 
   protected long getLong(Map<String, Object> fields, String key) {
     Object value = fields.get(key);

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkStreamHandlerConcurrencyTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/mavlink/MavlinkStreamHandlerConcurrencyTest.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ */
+
+package io.mapsmessaging.network.protocol.impl.mavlink;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.mapsmessaging.network.io.Packet;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class MavlinkStreamHandlerConcurrencyTest {
+
+  @Test
+  void inputAndOutputUseIndependentScratchBuffers() throws Exception {
+    byte[] frame = {
+      (byte) 0xFE,
+      4,
+      1,
+      2,
+      3,
+      4,
+      10,
+      11,
+      12,
+      13,
+      20,
+      21
+    };
+
+    CountDownLatch headerCopied = new CountDownLatch(1);
+    CountDownLatch outputCompleted = new CountDownLatch(1);
+    InputStream input =
+        new CoordinatedInputStream(frame, headerCopied, outputCompleted);
+    MavlinkStreamHandler handler = new MavlinkStreamHandler(2_000);
+    Packet inbound = new Packet(64, false);
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<Integer> read = executor.submit(() -> handler.parseInput(input, inbound));
+      assertTrue(headerCopied.await(1, TimeUnit.SECONDS));
+
+      Packet outbound =
+          new Packet(ByteBuffer.wrap(new byte[] {85, 85, 85, 85, 85, 85, 85, 85}));
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
+      try {
+        assertEquals(8, handler.parseOutput(output, outbound));
+      } finally {
+        outputCompleted.countDown();
+      }
+
+      assertEquals(frame.length, read.get(1, TimeUnit.SECONDS));
+      inbound.flip();
+      byte[] actual = new byte[inbound.available()];
+      inbound.get(actual);
+
+      assertArrayEquals(frame, actual);
+      assertArrayEquals(new byte[] {85, 85, 85, 85, 85, 85, 85, 85}, output.toByteArray());
+    } finally {
+      outputCompleted.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  private static final class CoordinatedInputStream extends InputStream {
+
+    private final byte[] data;
+    private final CountDownLatch headerCopied;
+    private final CountDownLatch outputCompleted;
+    private int position;
+    private boolean firstBulkRead = true;
+
+    private CoordinatedInputStream(
+        byte[] data,
+        CountDownLatch headerCopied,
+        CountDownLatch outputCompleted) {
+      this.data = data;
+      this.headerCopied = headerCopied;
+      this.outputCompleted = outputCompleted;
+    }
+
+    @Override
+    public int read() {
+      if (position >= data.length) {
+        return -1;
+      }
+      return data[position++] & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+      if (position >= data.length) {
+        return -1;
+      }
+
+      int count = Math.min(length, data.length - position);
+      System.arraycopy(data, position, buffer, offset, count);
+      position += count;
+
+      if (firstBulkRead) {
+        firstBulkRead = false;
+        headerCopied.countDown();
+        try {
+          if (!outputCompleted.await(1, TimeUnit.SECONDS)) {
+            throw new IOException("Timed out waiting for concurrent output");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted waiting for concurrent output", e);
+        }
+      }
+      return count;
+    }
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/packet/MavlinkPacketArrayTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/packet/MavlinkPacketArrayTest.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ */
+
+package io.mapsmessaging.state.mavlink.packet;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MavlinkPacketArrayTest {
+
+  private final TestPacket packet = new TestPacket();
+
+  @Test
+  void convertsJsonNumberListToIntArray() {
+    Map<String, Object> fields = Map.of("voltages", List.of(12001.0, 11998.0, 65535.0));
+
+    assertArrayEquals(
+        new int[] {12001, 11998, 65535}, packet.readIntArray(fields, "voltages"));
+  }
+
+  @Test
+  void rejectsListsContainingNonNumericValues() {
+    Map<String, Object> fields = Map.of("voltages", List.of(12001.0, "invalid"));
+
+    assertArrayEquals(new int[0], packet.readIntArray(fields, "voltages"));
+  }
+
+  private static final class TestPacket extends MavlinkPacket {
+
+    private int[] readIntArray(Map<String, Object> fields, String key) {
+      return getIntArray(fields, key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This change hardens the existing MAVLink implementation without changing the protocol architecture used elsewhere in MapsMessaging.

## Changes

- prevent logical UDP facade sessions from closing the shared physical UDP endpoint
- process packets received from configured forwarders through the normal MAVLink pipeline without forwarding loops
- contain failed session creation and always restore selector read registration
- retain and cancel scheduled MAVLink heartbeat tasks
- support serial endpoints without parsing their device name as a network socket
- separate serial input and output scratch buffers
- correct MAVLink v1 serial framing to read four header bytes after magic and payload length
- track MAVLink sequence state independently per component
- support JSON list-backed numeric arrays in typed MAVLink packets
- clean up twin observers and partially started state subscribers
- preserve model-provided detection contact identifiers
- contain malformed telemetry in the state subscriber

## Tests

- deterministic concurrent serial input/output regression test
- MAVLink v1 serial frame-length and byte-preservation coverage
- JSON numeric-list to integer-array conversion coverage
- invalid JSON array element coverage

## Scope

The MAVLink schema library remains responsible for MAVLink packet formats and encoding. These changes are limited to transport flow, session/state lifecycle, error containment, and the server-side handoff around that schema layer.