### PR TITLE
Merge plan task type prefix normalization into geospatial validation

### DIFF
--- a/.github/workflows/mavlink-area-mission-validation.yml
+++ b/.github/workflows/mavlink-area-mission-validation.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Run MAVLink mission tests
         run: >-
           mvn -B
-          -Dtest=MissionPlanRepeatTest,MavlinkCommandSetPreparerTest,MavlinkEventListSenderConcurrencyTest,SticklebackPassiveDetectionCapabilityTest
+          -Dtest=MissionPlanRepeatTest,MavlinkCommandSetPreparerTest,MavlinkEventListSenderConcurrencyTest,SticklebackPassiveDetectionCapabilityTest,PlanTaskTypeTest,TwinManagerConfigPlanTaskTypeTest
           test

--- a/src/main/java/io/mapsmessaging/state/config/TwinManagerConfig.java
+++ b/src/main/java/io/mapsmessaging/state/config/TwinManagerConfig.java
@@ -608,8 +608,7 @@ public class TwinManagerConfig extends TwinManagerConfigDTO implements Config, C
       return defaultValue;
     }
 
-    String normalisedValue = removePrefix(value, "PlanTaskTypeEnum_");
-    return PlanTaskType.valueOf(normalisedValue);
+    return PlanTaskType.fromConfigurationValue(value);
   }
 
   private TaskSpecialization parseTaskSpecialization(String value, TaskSpecialization defaultValue) {

--- a/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
+++ b/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
@@ -68,14 +68,15 @@ public enum PlanTaskType {
   BARRIER,
   INSPECT;
 
-  private static final String PREFIX = "PlanTaskType_";
+  private static final String WIRE_PREFIX = "PlanTaskType_";
+  private static final String ENUM_PREFIX = "PlanTaskTypeEnum_";
 
   public static PlanTaskType fromConfigurationValue(String value) {
     if (value == null || value.isBlank()) {
       throw new IllegalArgumentException("Plan task type is missing");
     }
 
-    String normalized = value.startsWith(PREFIX) ? value.substring(PREFIX.length()) : value;
+    String normalized = normalize(value);
     if (normalized.isBlank()) {
       throw new IllegalArgumentException("Plan task type is missing after prefix");
     }
@@ -88,7 +89,17 @@ public enum PlanTaskType {
   }
 
   public String toWireValue() {
-    return PREFIX + name();
+    return WIRE_PREFIX + name();
+  }
+
+  private static String normalize(String value) {
+    if (value.startsWith(WIRE_PREFIX)) {
+      return value.substring(WIRE_PREFIX.length());
+    }
+    if (value.startsWith(ENUM_PREFIX)) {
+      return value.substring(ENUM_PREFIX.length());
+    }
+    return value;
   }
 
   public static final class Adapter extends TypeAdapter<PlanTaskType> {

--- a/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
+++ b/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
@@ -71,6 +71,8 @@ public enum PlanTaskType {
   private static final String WIRE_PREFIX = "PlanTaskType_";
   private static final String ENUM_PREFIX = "PlanTaskTypeEnum_";
 
+  private static volatile String outboundPrefix = WIRE_PREFIX;
+
   public static PlanTaskType fromConfigurationValue(String value) {
     if (value == null || value.isBlank()) {
       throw new IllegalArgumentException("Plan task type is missing");
@@ -88,8 +90,16 @@ public enum PlanTaskType {
     }
   }
 
+  public static void configureEnumWirePrefix(boolean useEnumPrefix) {
+    outboundPrefix = useEnumPrefix ? ENUM_PREFIX : WIRE_PREFIX;
+  }
+
+  public static boolean isEnumWirePrefixConfigured() {
+    return ENUM_PREFIX.equals(outboundPrefix);
+  }
+
   public String toWireValue() {
-    return WIRE_PREFIX + name();
+    return outboundPrefix + name();
   }
 
   private static String normalize(String value) {

--- a/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
+++ b/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
@@ -87,6 +87,10 @@ public enum PlanTaskType {
     }
   }
 
+  public String toWireValue() {
+    return PREFIX + name();
+  }
+
   public static final class Adapter extends TypeAdapter<PlanTaskType> {
 
     @Override
@@ -95,7 +99,7 @@ public enum PlanTaskType {
         out.nullValue();
         return;
       }
-      out.value(value.name());
+      out.value(value.toWireValue());
     }
 
     @Override

--- a/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
+++ b/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
@@ -19,6 +19,15 @@
 
 package io.mapsmessaging.state.config.capability;
 
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+@JsonAdapter(PlanTaskType.Adapter.class)
 public enum PlanTaskType {
 
   REPOSITION,
@@ -57,6 +66,51 @@ public enum PlanTaskType {
   CLEAR,
   AVOID,
   BARRIER,
-  INSPECT
+  INSPECT;
 
+  private static final String PREFIX = "PlanTaskType_";
+
+  public static PlanTaskType fromConfigurationValue(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Plan task type is missing");
+    }
+
+    String normalized = value.startsWith(PREFIX) ? value.substring(PREFIX.length()) : value;
+    if (normalized.isBlank()) {
+      throw new IllegalArgumentException("Plan task type is missing after prefix");
+    }
+
+    try {
+      return PlanTaskType.valueOf(normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("Unknown plan task type: " + value, exception);
+    }
+  }
+
+  public static final class Adapter extends TypeAdapter<PlanTaskType> {
+
+    @Override
+    public void write(JsonWriter out, PlanTaskType value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+        return;
+      }
+      out.value(value.name());
+    }
+
+    @Override
+    public PlanTaskType read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+
+      String value = in.nextString();
+      try {
+        return PlanTaskType.fromConfigurationValue(value);
+      } catch (IllegalArgumentException exception) {
+        throw new JsonParseException(exception.getMessage(), exception);
+      }
+    }
+  }
 }

--- a/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
+++ b/src/main/java/io/mapsmessaging/state/config/capability/PlanTaskType.java
@@ -71,8 +71,6 @@ public enum PlanTaskType {
   private static final String WIRE_PREFIX = "PlanTaskType_";
   private static final String ENUM_PREFIX = "PlanTaskTypeEnum_";
 
-  private static volatile String outboundPrefix = WIRE_PREFIX;
-
   public static PlanTaskType fromConfigurationValue(String value) {
     if (value == null || value.isBlank()) {
       throw new IllegalArgumentException("Plan task type is missing");
@@ -90,16 +88,8 @@ public enum PlanTaskType {
     }
   }
 
-  public static void configureEnumWirePrefix(boolean useEnumPrefix) {
-    outboundPrefix = useEnumPrefix ? ENUM_PREFIX : WIRE_PREFIX;
-  }
-
-  public static boolean isEnumWirePrefixConfigured() {
-    return ENUM_PREFIX.equals(outboundPrefix);
-  }
-
   public String toWireValue() {
-    return outboundPrefix + name();
+    return WIRE_PREFIX + name();
   }
 
   private static String normalize(String value) {

--- a/src/test/java/io/mapsmessaging/state/config/TwinManagerConfigPlanTaskTypeTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/TwinManagerConfigPlanTaskTypeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ */
+
+package io.mapsmessaging.state.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.state.config.capability.PlanTaskType;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TwinManagerConfigPlanTaskTypeTest {
+
+  @Test
+  void loadsBarePlanTaskType() throws Exception {
+    assertLoadedTaskType("SCREEN", PlanTaskType.SCREEN);
+  }
+
+  @Test
+  void loadsPlanTaskTypePrefix() throws Exception {
+    assertLoadedTaskType("PlanTaskType_SCREEN", PlanTaskType.SCREEN);
+  }
+
+  @Test
+  void loadsPlanTaskTypeEnumPrefix() throws Exception {
+    assertLoadedTaskType("PlanTaskTypeEnum_SCREEN", PlanTaskType.SCREEN);
+  }
+
+  private void assertLoadedTaskType(String configuredValue, PlanTaskType expected)
+      throws Exception {
+    TwinManagerConfig config = loadConfig(configuredValue);
+
+    PlanTaskType actual =
+        config.getDroneInfo()
+            .get(0)
+            .getCapabilities()
+            .getTasks()
+            .get(0)
+            .getTaskType();
+
+    assertEquals(expected, actual);
+  }
+
+  private TwinManagerConfig loadConfig(String taskType) throws Exception {
+    ConfigurationProperties taskCapability = new ConfigurationProperties();
+    taskCapability.put("task_type", taskType);
+
+    ConfigurationProperties capabilities = new ConfigurationProperties();
+    capabilities.put("tasks", List.of(taskCapability));
+
+    ConfigurationProperties drone = new ConfigurationProperties();
+    drone.put("name", "USV-001");
+    drone.put("capabilities", capabilities);
+
+    ConfigurationProperties root = new ConfigurationProperties();
+    root.put("droneInfo", List.of(drone));
+
+    Constructor<TwinManagerConfig> constructor =
+        TwinManagerConfig.class.getDeclaredConstructor(ConfigurationProperties.class);
+    constructor.setAccessible(true);
+    return constructor.newInstance(root);
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
@@ -12,26 +12,18 @@
 package io.mapsmessaging.state.config.capability;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import io.mapsmessaging.configuration.SystemProperties;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class PlanTaskTypeTest {
 
   private final Gson gson = SystemProperties.getInstance().getGson();
-
-  @AfterEach
-  void restoreDefaultWirePrefix() {
-    PlanTaskType.configureEnumWirePrefix(false);
-  }
 
   @Test
   void parsesLegacyTaskTypeValue() {
@@ -62,30 +54,18 @@ class PlanTaskTypeTest {
   }
 
   @Test
-  void defaultsToPlanTaskTypeWirePrefix() {
-    assertFalse(PlanTaskType.isEnumWirePrefixConfigured());
-
-    assertSerializedTaskType("PlanTaskType_SCREEN");
-  }
-
-  @Test
-  void canSerializeUsingPlanTaskTypeEnumWirePrefix() {
-    PlanTaskType.configureEnumWirePrefix(true);
-
-    assertTrue(PlanTaskType.isEnumWirePrefixConfigured());
-    assertSerializedTaskType("PlanTaskTypeEnum_SCREEN");
-  }
-
-  @Test
-  void legacyInputSerializesBackUsingConfiguredWirePrefix() {
-    TaskCapability capability =
-        gson.fromJson("{\"task_type\":\"SCREEN\"}", TaskCapability.class);
+  void serializesUsingCanonicalPlanTaskTypePrefix() {
+    TaskCapability capability = new TaskCapability();
+    capability.setTaskType(PlanTaskType.SCREEN);
 
     assertEquals("PlanTaskType_SCREEN", serializedTaskType(capability));
+  }
 
-    PlanTaskType.configureEnumWirePrefix(true);
-
-    assertEquals("PlanTaskTypeEnum_SCREEN", serializedTaskType(capability));
+  @Test
+  void allAcceptedInputsSerializeToCanonicalWireValue() {
+    assertCanonicalRoundTrip("SCREEN");
+    assertCanonicalRoundTrip("PlanTaskType_SCREEN");
+    assertCanonicalRoundTrip("PlanTaskTypeEnum_SCREEN");
   }
 
   @Test
@@ -108,11 +88,13 @@ class PlanTaskTypeTest {
                 TaskCapability.class));
   }
 
-  private void assertSerializedTaskType(String expected) {
-    TaskCapability capability = new TaskCapability();
-    capability.setTaskType(PlanTaskType.SCREEN);
+  private void assertCanonicalRoundTrip(String taskType) {
+    TaskCapability capability =
+        gson.fromJson(
+            "{\"task_type\":\"" + taskType + "\"}",
+            TaskCapability.class);
 
-    assertEquals(expected, serializedTaskType(capability));
+    assertEquals("PlanTaskType_SCREEN", serializedTaskType(capability));
   }
 
   private String serializedTaskType(TaskCapability capability) {

--- a/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
@@ -37,34 +37,47 @@ class PlanTaskTypeTest {
   void stripsPlanTaskTypePrefix() {
     TaskCapability capability =
         gson.fromJson(
-            "{\"task_type\":\"PlanTaskType_NAVIGATE\"}",
+            "{\"task_type\":\"PlanTaskType_SCREEN\"}",
             TaskCapability.class);
 
-    assertEquals(PlanTaskType.NAVIGATE, capability.getTaskType());
+    assertEquals(PlanTaskType.SCREEN, capability.getTaskType());
+  }
+
+  @Test
+  void stripsPlanTaskTypeEnumPrefix() {
+    TaskCapability capability =
+        gson.fromJson(
+            "{\"task_type\":\"PlanTaskTypeEnum_SCREEN\"}",
+            TaskCapability.class);
+
+    assertEquals(PlanTaskType.SCREEN, capability.getTaskType());
   }
 
   @Test
   void serializesTaskCapabilityWithCanonicalPlanTaskTypePrefix() {
     TaskCapability capability = new TaskCapability();
-    capability.setTaskType(PlanTaskType.NAVIGATE);
+    capability.setTaskType(PlanTaskType.SCREEN);
 
     JsonObject serialized = JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
 
     assertEquals(
-        "PlanTaskType_NAVIGATE",
+        "PlanTaskType_SCREEN",
         serialized.get("task_type").getAsString());
   }
 
   @Test
   void legacyInputSerializesBackToCanonicalWireValue() {
-    TaskCapability capability =
-        gson.fromJson("{\"task_type\":\"NAVIGATE\"}", TaskCapability.class);
+    assertCanonicalRoundTrip("SCREEN");
+  }
 
-    JsonObject serialized = JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
+  @Test
+  void planTaskTypeInputSerializesBackToCanonicalWireValue() {
+    assertCanonicalRoundTrip("PlanTaskType_SCREEN");
+  }
 
-    assertEquals(
-        "PlanTaskType_NAVIGATE",
-        serialized.get("task_type").getAsString());
+  @Test
+  void planTaskTypeEnumInputSerializesBackToCanonicalWireValue() {
+    assertCanonicalRoundTrip("PlanTaskTypeEnum_SCREEN");
   }
 
   @Test
@@ -75,5 +88,28 @@ class PlanTaskTypeTest {
             gson.fromJson(
                 "{\"task_type\":\"PlanTaskType_NOT_A_TASK\"}",
                 TaskCapability.class));
+  }
+
+  @Test
+  void rejectsUnknownEnumPrefixedTaskType() {
+    assertThrows(
+        JsonParseException.class,
+        () ->
+            gson.fromJson(
+                "{\"task_type\":\"PlanTaskTypeEnum_NOT_A_TASK\"}",
+                TaskCapability.class));
+  }
+
+  private void assertCanonicalRoundTrip(String taskType) {
+    TaskCapability capability =
+        gson.fromJson(
+            "{\"task_type\":\"" + taskType + "\"}",
+            TaskCapability.class);
+
+    JsonObject serialized = JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
+
+    assertEquals(
+        "PlanTaskType_SCREEN",
+        serialized.get("task_type").getAsString());
   }
 }

--- a/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
@@ -15,7 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 import io.mapsmessaging.configuration.SystemProperties;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +41,30 @@ class PlanTaskTypeTest {
             TaskCapability.class);
 
     assertEquals(PlanTaskType.NAVIGATE, capability.getTaskType());
+  }
+
+  @Test
+  void serializesTaskCapabilityWithCanonicalPlanTaskTypePrefix() {
+    TaskCapability capability = new TaskCapability();
+    capability.setTaskType(PlanTaskType.NAVIGATE);
+
+    JsonObject serialized = JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
+
+    assertEquals(
+        "PlanTaskType_NAVIGATE",
+        serialized.get("task_type").getAsString());
+  }
+
+  @Test
+  void legacyInputSerializesBackToCanonicalWireValue() {
+    TaskCapability capability =
+        gson.fromJson("{\"task_type\":\"NAVIGATE\"}", TaskCapability.class);
+
+    JsonObject serialized = JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
+
+    assertEquals(
+        "PlanTaskType_NAVIGATE",
+        serialized.get("task_type").getAsString());
   }
 
   @Test

--- a/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
@@ -12,18 +12,26 @@
 package io.mapsmessaging.state.config.capability;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import io.mapsmessaging.configuration.SystemProperties;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class PlanTaskTypeTest {
 
   private final Gson gson = SystemProperties.getInstance().getGson();
+
+  @AfterEach
+  void restoreDefaultWirePrefix() {
+    PlanTaskType.configureEnumWirePrefix(false);
+  }
 
   @Test
   void parsesLegacyTaskTypeValue() {
@@ -54,30 +62,30 @@ class PlanTaskTypeTest {
   }
 
   @Test
-  void serializesTaskCapabilityWithCanonicalPlanTaskTypePrefix() {
-    TaskCapability capability = new TaskCapability();
-    capability.setTaskType(PlanTaskType.SCREEN);
+  void defaultsToPlanTaskTypeWirePrefix() {
+    assertFalse(PlanTaskType.isEnumWirePrefixConfigured());
 
-    JsonObject serialized = JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
-
-    assertEquals(
-        "PlanTaskType_SCREEN",
-        serialized.get("task_type").getAsString());
+    assertSerializedTaskType("PlanTaskType_SCREEN");
   }
 
   @Test
-  void legacyInputSerializesBackToCanonicalWireValue() {
-    assertCanonicalRoundTrip("SCREEN");
+  void canSerializeUsingPlanTaskTypeEnumWirePrefix() {
+    PlanTaskType.configureEnumWirePrefix(true);
+
+    assertTrue(PlanTaskType.isEnumWirePrefixConfigured());
+    assertSerializedTaskType("PlanTaskTypeEnum_SCREEN");
   }
 
   @Test
-  void planTaskTypeInputSerializesBackToCanonicalWireValue() {
-    assertCanonicalRoundTrip("PlanTaskType_SCREEN");
-  }
+  void legacyInputSerializesBackUsingConfiguredWirePrefix() {
+    TaskCapability capability =
+        gson.fromJson("{\"task_type\":\"SCREEN\"}", TaskCapability.class);
 
-  @Test
-  void planTaskTypeEnumInputSerializesBackToCanonicalWireValue() {
-    assertCanonicalRoundTrip("PlanTaskTypeEnum_SCREEN");
+    assertEquals("PlanTaskType_SCREEN", serializedTaskType(capability));
+
+    PlanTaskType.configureEnumWirePrefix(true);
+
+    assertEquals("PlanTaskTypeEnum_SCREEN", serializedTaskType(capability));
   }
 
   @Test
@@ -100,16 +108,16 @@ class PlanTaskTypeTest {
                 TaskCapability.class));
   }
 
-  private void assertCanonicalRoundTrip(String taskType) {
-    TaskCapability capability =
-        gson.fromJson(
-            "{\"task_type\":\"" + taskType + "\"}",
-            TaskCapability.class);
+  private void assertSerializedTaskType(String expected) {
+    TaskCapability capability = new TaskCapability();
+    capability.setTaskType(PlanTaskType.SCREEN);
 
-    JsonObject serialized = JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
+    assertEquals(expected, serializedTaskType(capability));
+  }
 
-    assertEquals(
-        "PlanTaskType_SCREEN",
-        serialized.get("task_type").getAsString());
+  private String serializedTaskType(TaskCapability capability) {
+    JsonObject serialized =
+        JsonParser.parseString(gson.toJson(capability)).getAsJsonObject();
+    return serialized.get("task_type").getAsString();
   }
 }

--- a/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
@@ -16,11 +16,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
+import io.mapsmessaging.configuration.SystemProperties;
 import org.junit.jupiter.api.Test;
 
 class PlanTaskTypeTest {
 
-  private final Gson gson = new Gson();
+  private final Gson gson = SystemProperties.getInstance().getGson();
 
   @Test
   void parsesLegacyTaskTypeValue() {

--- a/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/capability/PlanTaskTypeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ * (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://commonsclause.com/
+ */
+
+package io.mapsmessaging.state.config.capability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import org.junit.jupiter.api.Test;
+
+class PlanTaskTypeTest {
+
+  private final Gson gson = new Gson();
+
+  @Test
+  void parsesLegacyTaskTypeValue() {
+    TaskCapability capability =
+        gson.fromJson("{\"task_type\":\"NAVIGATE\"}", TaskCapability.class);
+
+    assertEquals(PlanTaskType.NAVIGATE, capability.getTaskType());
+  }
+
+  @Test
+  void stripsPlanTaskTypePrefix() {
+    TaskCapability capability =
+        gson.fromJson(
+            "{\"task_type\":\"PlanTaskType_NAVIGATE\"}",
+            TaskCapability.class);
+
+    assertEquals(PlanTaskType.NAVIGATE, capability.getTaskType());
+  }
+
+  @Test
+  void rejectsUnknownPrefixedTaskType() {
+    assertThrows(
+        JsonParseException.class,
+        () ->
+            gson.fromJson(
+                "{\"task_type\":\"PlanTaskType_NOT_A_TASK\"}",
+                TaskCapability.class));
+  }
+}


### PR DESCRIPTION
Combines `agent/plan-task-type-prefix-normalization` with `feature/geospatial-boundary-validation`.

This preserves the standalone geospatial package and TwinManager geospatial configuration while adding normalized `PlanTaskType` parsing and its regression tests.