### PR TITLE
Preserve TLS client certificate configuration

### DIFF
--- a/src/main/java/io/mapsmessaging/config/network/SslConfig.java
+++ b/src/main/java/io/mapsmessaging/config/network/SslConfig.java
@@ -33,8 +33,8 @@ public class SslConfig extends SslConfigDTO implements Config  {
   public SslConfig(ConfigurationProperties config) {
     ConfigurationProperties securityProps = locateConfig(config);
     this.context = securityProps.getProperty("context", "tls");
-    this.clientCertificateRequired = config.getBooleanProperty("clientCertificateRequired", false);
-    this.clientCertificateWanted = config.getBooleanProperty("clientCertificateWanted", false);
+    this.clientCertificateRequired = securityProps.getBooleanProperty("clientCertificateRequired", false);
+    this.clientCertificateWanted = securityProps.getBooleanProperty("clientCertificateWanted", false);
     this.crlUrl = config.getProperty("crlUrl", null);
     this.crlInterval = config.getLongProperty("crlInterval", 0);
 

--- a/src/main/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPoint.java
+++ b/src/main/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPoint.java
@@ -231,7 +231,7 @@ public class SSLEndPoint extends TCPEndPoint {
 
   @Override
   public Principal getEndPointPrincipal() {
-    if (sslEngine.getNeedClientAuth()) {
+    if (sslEngine.getNeedClientAuth() || sslEngine.getWantClientAuth()) {
       try {
         return sslEngine.getSession().getPeerPrincipal();
       } catch (SSLPeerUnverifiedException e) {

--- a/src/test/java/io/mapsmessaging/config/network/SslConfigTest.java
+++ b/src/test/java/io/mapsmessaging/config/network/SslConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.config.network;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import org.junit.jupiter.api.Test;
+
+class SslConfigTest {
+
+  @Test
+  void constructorReadsClientCertificateSettingsFromNestedTlsConfiguration() {
+    ConfigurationProperties keyStore = new ConfigurationProperties();
+    keyStore.put("type", "JKS");
+    keyStore.put("managerFactory", "SunX509");
+
+    ConfigurationProperties tls = new ConfigurationProperties();
+    tls.put("clientCertificateRequired", true);
+    tls.put("clientCertificateWanted", false);
+    tls.put("keyStore", keyStore);
+    tls.put("trustStore", keyStore);
+
+    ConfigurationProperties security = new ConfigurationProperties();
+    security.put("tls", tls);
+
+    ConfigurationProperties config = new ConfigurationProperties();
+    config.put("security", security);
+
+    SslConfig sslConfig = new SslConfig(config);
+
+    assertTrue(sslConfig.isClientCertificateRequired());
+    assertFalse(sslConfig.isClientCertificateWanted());
+  }
+}


### PR DESCRIPTION
## What changed

- read client-certificate flags from the located security.tls configuration
- expose a peer principal when either required or optional client authentication is enabled
- add regression coverage for nested TLS configuration

## Root cause

SslConfig located the nested TLS block but read clientCertificateRequired and clientCertificateWanted from the outer endpoint configuration. SSLEndPoint also restricted principal extraction to required authentication only.

## Impact

Configured client-certificate modes now reach the SSL engine, and optionally supplied client certificates can contribute the endpoint principal.

## Validation

Added a unit test for nested security.tls client-certificate settings.

## Dependency

The mandatory-handshake enforcement fix is in the companion authentication_library pull request from the same branch name.