### PR TITLE
fix(network): harden TLS and DTLS security configuration

### DIFF
--- a/src/main/java/io/mapsmessaging/config/NetworkManagerConfig.java
+++ b/src/main/java/io/mapsmessaging/config/NetworkManagerConfig.java
@@ -101,7 +101,7 @@ public class NetworkManagerConfig extends NetworkManagerConfigDTO implements Con
       }
       if(name.equals(endPointServerConfig.getName())
           && endPointServerConfigDTO instanceof EndPointServerConfig) {
-        return ((EndPointServerConfig) endPointServerConfig).update(endPointServerConfigDTO);
+        return ((EndPointServerConfig) endPointServerConfigDTO).update(endPointServerConfig);
       }
     }
     return false;

--- a/src/main/java/io/mapsmessaging/config/network/KeyStoreConfig.java
+++ b/src/main/java/io/mapsmessaging/config/network/KeyStoreConfig.java
@@ -23,6 +23,7 @@ import io.mapsmessaging.config.Config;
 import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.dto.rest.config.BaseConfigDTO;
 import io.mapsmessaging.dto.rest.config.network.KeyStoreConfigDTO;
+import java.util.Objects;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -45,31 +46,31 @@ public class KeyStoreConfig extends KeyStoreConfigDTO implements Config {
     boolean hasChanged = false;
     if (config instanceof KeyStoreConfigDTO) {
       KeyStoreConfigDTO newConfig = (KeyStoreConfigDTO) config;
-      if (!this.alias.equals(newConfig.getAlias())) {
+      if (!Objects.equals(this.alias, newConfig.getAlias())) {
         this.alias = newConfig.getAlias();
         hasChanged = true;
       }
-      if (!this.type.equals(newConfig.getType())) {
+      if (!Objects.equals(this.type, newConfig.getType())) {
         this.type = newConfig.getType();
         hasChanged = true;
       }
-      if (!this.providerName.equals(newConfig.getProviderName())) {
+      if (!Objects.equals(this.providerName, newConfig.getProviderName())) {
         this.providerName = newConfig.getProviderName();
         hasChanged = true;
       }
-      if (!this.managerFactory.equals(newConfig.getManagerFactory())) {
+      if (!Objects.equals(this.managerFactory, newConfig.getManagerFactory())) {
         this.managerFactory = newConfig.getManagerFactory();
         hasChanged = true;
       }
-      if (!this.path.equals(newConfig.getPath())) {
+      if (!Objects.equals(this.path, newConfig.getPath())) {
         this.path = newConfig.getPath();
         hasChanged = true;
       }
-      if (!this.passphrase.equals(newConfig.getPassphrase())) {
+      if (!Objects.equals(this.passphrase, newConfig.getPassphrase())) {
         this.passphrase = newConfig.getPassphrase();
         hasChanged = true;
       }
-      if (!this.provider.equals(newConfig.getProvider())) {
+      if (!Objects.equals(this.provider, newConfig.getProvider())) {
         this.provider = newConfig.getProvider();
         hasChanged = true;
       }

--- a/src/main/java/io/mapsmessaging/config/network/SslConfig.java
+++ b/src/main/java/io/mapsmessaging/config/network/SslConfig.java
@@ -41,7 +41,7 @@ public class SslConfig extends SslConfigDTO implements Config {
       throw new IllegalArgumentException("Missing security." + transport + " configuration");
     }
 
-    String defaultContext = "dtls".equalsIgnoreCase(transport) ? "DTLSv1.2" : "TLSv1.3";
+    String defaultContext = "dtls".equalsIgnoreCase(transport) ? "DTLSv1.2" : "TLS";
     this.context = securityProps.getProperty("context", defaultContext);
     this.clientCertificateRequired = securityProps.getBooleanProperty("clientCertificateRequired", false);
     this.clientCertificateWanted = securityProps.getBooleanProperty("clientCertificateWanted", false);

--- a/src/main/java/io/mapsmessaging/config/network/SslConfig.java
+++ b/src/main/java/io/mapsmessaging/config/network/SslConfig.java
@@ -23,77 +23,97 @@ import io.mapsmessaging.config.Config;
 import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.dto.rest.config.BaseConfigDTO;
 import io.mapsmessaging.dto.rest.config.network.SslConfigDTO;
+import java.util.Objects;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
-public class SslConfig extends SslConfigDTO implements Config  {
+public class SslConfig extends SslConfigDTO implements Config {
 
   public SslConfig(ConfigurationProperties config) {
-    ConfigurationProperties securityProps = locateConfig(config);
-    this.context = securityProps.getProperty("context", "tls");
-    this.clientCertificateRequired = config.getBooleanProperty("clientCertificateRequired", false);
-    this.clientCertificateWanted = config.getBooleanProperty("clientCertificateWanted", false);
-    this.crlUrl = config.getProperty("crlUrl", null);
-    this.crlInterval = config.getLongProperty("crlInterval", 0);
+    this(config, "tls");
+  }
 
+  public SslConfig(ConfigurationProperties config, String transport) {
+    ConfigurationProperties securityProps = locateConfig(config, transport);
+    if (securityProps == null) {
+      throw new IllegalArgumentException("Missing security." + transport + " configuration");
+    }
+
+    String defaultContext = "dtls".equalsIgnoreCase(transport) ? "DTLSv1.2" : "TLSv1.3";
+    this.context = securityProps.getProperty("context", defaultContext);
+    this.clientCertificateRequired = securityProps.getBooleanProperty("clientCertificateRequired", false);
+    this.clientCertificateWanted = securityProps.getBooleanProperty("clientCertificateWanted", false);
+    this.hostnameVerificationEnabled = securityProps.getBooleanProperty("hostnameVerificationEnabled", true);
+    this.crlUrl = securityProps.getProperty("crlUrl", null);
+    this.crlInterval = securityProps.getLongProperty("crlInterval", 3600000L);
     this.keyStore = new KeyStoreConfig((ConfigurationProperties) securityProps.get("keyStore"));
     this.trustStore = new KeyStoreConfig((ConfigurationProperties) securityProps.get("trustStore"));
   }
 
-  private ConfigurationProperties locateConfig(ConfigurationProperties config) {
-    if (config.containsKey("clientCertificateRequired")) {
+  private ConfigurationProperties locateConfig(ConfigurationProperties config, String transport) {
+    if (config.containsKey("keyStore") || config.containsKey("trustStore") || config.containsKey("clientCertificateRequired")) {
       return config;
-    }
-    ConfigurationProperties security = (ConfigurationProperties) config.get("security");
-    if (security != null) {
-      security = (ConfigurationProperties) security.get("tls");
     }
 
     ConfigurationProperties endPoint = (ConfigurationProperties) config.get("endPoint");
     if (endPoint != null) {
-      return locateConfig(endPoint);
+      ConfigurationProperties endPointSecurity = locateConfig(endPoint, transport);
+      if (endPointSecurity != null) {
+        return endPointSecurity;
+      }
     }
 
-    return security;
+    ConfigurationProperties security = (ConfigurationProperties) config.get("security");
+    return security == null ? null : (ConfigurationProperties) security.get(transport);
   }
 
   public boolean update(BaseConfigDTO config) {
-    boolean hasChanged = false;
-    if (config instanceof SslConfigDTO) {
-      SslConfigDTO newConfig = (SslConfigDTO) config;
+    if (!(config instanceof SslConfigDTO newConfig)) {
+      return false;
+    }
 
-      if (this.clientCertificateRequired != newConfig.isClientCertificateRequired()) {
-        this.clientCertificateRequired = newConfig.isClientCertificateRequired();
-        hasChanged = true;
-      }
-      if (this.clientCertificateWanted != newConfig.isClientCertificateWanted()) {
-        this.clientCertificateWanted = newConfig.isClientCertificateWanted();
-        hasChanged = true;
-      }
-      if (!this.crlUrl.equals(newConfig.getCrlUrl())) {
-        this.crlUrl = newConfig.getCrlUrl();
-        hasChanged = true;
-      }
-      if (this.crlInterval != newConfig.getCrlInterval()) {
-        this.crlInterval = newConfig.getCrlInterval();
-        hasChanged = true;
-      }
-      if (((KeyStoreConfig)this.keyStore).update(newConfig.getKeyStore())) {
-        hasChanged = true;
-      }
-      if (((KeyStoreConfig)this.trustStore).update(newConfig.getTrustStore())) {
-        hasChanged = true;
-      }
+    boolean hasChanged = false;
+    if (this.clientCertificateRequired != newConfig.isClientCertificateRequired()) {
+      this.clientCertificateRequired = newConfig.isClientCertificateRequired();
+      hasChanged = true;
+    }
+    if (this.clientCertificateWanted != newConfig.isClientCertificateWanted()) {
+      this.clientCertificateWanted = newConfig.isClientCertificateWanted();
+      hasChanged = true;
+    }
+    if (this.hostnameVerificationEnabled != newConfig.isHostnameVerificationEnabled()) {
+      this.hostnameVerificationEnabled = newConfig.isHostnameVerificationEnabled();
+      hasChanged = true;
+    }
+    if (!Objects.equals(this.context, newConfig.getContext())) {
+      this.context = newConfig.getContext();
+      hasChanged = true;
+    }
+    if (!Objects.equals(this.crlUrl, newConfig.getCrlUrl())) {
+      this.crlUrl = newConfig.getCrlUrl();
+      hasChanged = true;
+    }
+    if (this.crlInterval != newConfig.getCrlInterval()) {
+      this.crlInterval = newConfig.getCrlInterval();
+      hasChanged = true;
+    }
+    if (newConfig.getKeyStore() != null && ((KeyStoreConfig) this.keyStore).update(newConfig.getKeyStore())) {
+      hasChanged = true;
+    }
+    if (newConfig.getTrustStore() != null && ((KeyStoreConfig) this.trustStore).update(newConfig.getTrustStore())) {
+      hasChanged = true;
     }
     return hasChanged;
   }
 
   public ConfigurationProperties toConfigurationProperties() {
     ConfigurationProperties config = new ConfigurationProperties();
+    config.put("context", this.context);
     config.put("clientCertificateRequired", this.clientCertificateRequired);
     config.put("clientCertificateWanted", this.clientCertificateWanted);
+    config.put("hostnameVerificationEnabled", this.hostnameVerificationEnabled);
     config.put("crlUrl", this.crlUrl);
     config.put("crlInterval", this.crlInterval);
     config.put("keyStore", ((KeyStoreConfig) keyStore).toConfigurationProperties());

--- a/src/main/java/io/mapsmessaging/config/network/impl/DtlsConfig.java
+++ b/src/main/java/io/mapsmessaging/config/network/impl/DtlsConfig.java
@@ -38,19 +38,20 @@ public class DtlsConfig extends DtlsConfigDTO implements Config {
   public DtlsConfig(ConfigurationProperties config) {
     setType("dtls");
     NetworkConfigFactory.unpack(config, this);
-    sslConfig = new SslConfig(config);
+    sslConfig = new SslConfig(config, "dtls");
     if(!sslConfig.getContext().toLowerCase().startsWith("dtls")){
       sslConfig.setContext("DTLSv1.2");
     }
   }
 
   public boolean update(BaseConfigDTO update) {
-    boolean hasChanged = false;
-    if (update instanceof DtlsConfigDTO) {
-      hasChanged = NetworkConfigFactory.update(this, (DtlsConfigDTO) update);
-      if(((SslConfig)sslConfig).update(update)){
-        hasChanged = true;
-      }
+    if (!(update instanceof DtlsConfigDTO newConfig)) {
+      return false;
+    }
+
+    boolean hasChanged = NetworkConfigFactory.update(this, newConfig);
+    if (newConfig.getSslConfig() != null && ((SslConfig) sslConfig).update(newConfig.getSslConfig())) {
+      hasChanged = true;
     }
     return hasChanged;
   }
@@ -62,4 +63,5 @@ public class DtlsConfig extends DtlsConfigDTO implements Config {
     security.put("dtls", ((SslConfig)sslConfig).toConfigurationProperties());
     config.put("security", security);
     return config;
-  }}
+  }
+}

--- a/src/main/java/io/mapsmessaging/config/network/impl/TlsConfig.java
+++ b/src/main/java/io/mapsmessaging/config/network/impl/TlsConfig.java
@@ -23,7 +23,6 @@ import io.mapsmessaging.config.Config;
 import io.mapsmessaging.config.network.SslConfig;
 import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.dto.rest.config.BaseConfigDTO;
-import io.mapsmessaging.dto.rest.config.network.impl.TcpConfigDTO;
 import io.mapsmessaging.dto.rest.config.network.impl.TlsConfigDTO;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -38,21 +37,21 @@ public class TlsConfig extends TlsConfigDTO implements Config {
 
   public TlsConfig(ConfigurationProperties config) {
     NetworkConfigFactory.unpack(config, this);
-    sslConfig = new SslConfig(config);
+    sslConfig = new SslConfig(config, "tls");
     if(sslConfig.getContext() == null || sslConfig.getContext().isEmpty()) {
       sslConfig.setContext("TLSv1.3");
     }
   }
 
   public boolean update(BaseConfigDTO update) {
-    boolean hasChanged = false;
-    if (update instanceof TcpConfigDTO) {
-      hasChanged = NetworkConfigFactory.update(this, (TcpConfigDTO) update);
-      if(((SslConfig)sslConfig).update(update)){
-        hasChanged = true;
-      }
+    if (!(update instanceof TlsConfigDTO newConfig)) {
+      return false;
     }
 
+    boolean hasChanged = NetworkConfigFactory.update(this, newConfig);
+    if (newConfig.getSslConfig() != null && ((SslConfig) sslConfig).update(newConfig.getSslConfig())) {
+      hasChanged = true;
+    }
     return hasChanged;
   }
 

--- a/src/main/java/io/mapsmessaging/dto/rest/config/network/SslConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/config/network/SslConfigDTO.java
@@ -81,10 +81,10 @@ public class SslConfigDTO extends BaseConfigDTO {
   protected long crlInterval = 3600000L;
 
   @Schema(
-      description = "SSL context identifier or protocol profile to use (for example: TLS, TLSv1.2, TLSv1.3).",
+      description = "SSL context identifier or protocol profile to use (for example: TLS, TLSv1.3, DTLS, DTLSv1.2).",
       example = "TLS",
       defaultValue = "TLS",
-      pattern = "^TLS(?:v1\\.(?:2|3))?$",
+      pattern = "^(?:TLS(?:v1\\.(?:2|3))?|DTLS(?:v1\\.(?:0|2))?)$",
       requiredMode = Schema.RequiredMode.REQUIRED,
       nullable = false
   )

--- a/src/main/java/io/mapsmessaging/dto/rest/config/network/SslConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/config/network/SslConfigDTO.java
@@ -51,6 +51,15 @@ public class SslConfigDTO extends BaseConfigDTO {
   protected boolean clientCertificateWanted = false;
 
   @Schema(
+      description = "Whether outbound TLS connections verify the server certificate hostname.",
+      example = "true",
+      defaultValue = "true",
+      requiredMode = Schema.RequiredMode.REQUIRED,
+      nullable = false
+  )
+  protected boolean hostnameVerificationEnabled = true;
+
+  @Schema(
       description = "URL for the Certificate Revocation List (CRL). " +
           "If not set, CRL checking is disabled.",
       example = "http://example.com/crl.pem",

--- a/src/main/java/io/mapsmessaging/network/io/impl/dtls/DTLSEndPoint.java
+++ b/src/main/java/io/mapsmessaging/network/io/impl/dtls/DTLSEndPoint.java
@@ -21,6 +21,7 @@ package io.mapsmessaging.network.io.impl.dtls;
 
 import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
+import io.mapsmessaging.logging.ServerLogMessages;
 import io.mapsmessaging.network.admin.EndPointJMX;
 import io.mapsmessaging.network.admin.EndPointManagerJMX;
 import io.mapsmessaging.network.io.*;
@@ -33,7 +34,10 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
+import java.security.Principal;
 import java.util.concurrent.FutureTask;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
 
 public class DTLSEndPoint extends EndPoint implements StateChangeListener, Timeoutable {
 
@@ -126,6 +130,24 @@ public class DTLSEndPoint extends EndPoint implements StateChangeListener, Timeo
     } catch (IOException e) {
       close();
     }
+  }
+
+  @Override
+  public Principal getEndPointPrincipal() {
+    SSLEngine sslEngine = stateEngine.getSslEngine();
+    if (sslEngine.getNeedClientAuth() || sslEngine.getWantClientAuth()) {
+      try {
+        return sslEngine.getSession().getPeerPrincipal();
+      } catch (SSLPeerUnverifiedException e) {
+        logger.log(ServerLogMessages.SSL_ENGINE_CLIENT_AUTH);
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean isSSL() {
+    return true;
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/network/io/impl/dtls/DTLSSessionManager.java
+++ b/src/main/java/io/mapsmessaging/network/io/impl/dtls/DTLSSessionManager.java
@@ -90,11 +90,7 @@ public class DTLSSessionManager implements Closeable, SelectorCallback {
     if (state == null) {
       StateEngine stateEngine;
       SSLEngine sslEngine = SslHelper.createSSLEngine(sslContext, ((Config)((DtlsConfig)udpEndPoint.getConfig().getEndPointConfig()).getSslConfig()).toConfigurationProperties());
-      SSLParameters paras = sslEngine.getSSLParameters();
-      int mtu = 8192;
-      paras.setMaximumPacketSize(mtu);
-      paras.setEnableRetransmissions(true);
-      sslEngine.setSSLParameters(paras);
+      configureEngine(sslEngine);
       stateEngine = new StateEngine(packet.getFromAddress(), sslEngine, this);
       endPoint = new DTLSEndPoint(this, uniqueId.incrementAndGet(), packet.getFromAddress(), server, stateEngine, managerMBean);
       sessionMapping.addState(packet.getFromAddress(), new UDPSessionState<>(endPoint));
@@ -109,6 +105,13 @@ public class DTLSSessionManager implements Closeable, SelectorCallback {
       return false;
     }
     return true;
+  }
+
+  static void configureEngine(SSLEngine sslEngine) {
+    SSLParameters sslParameters = sslEngine.getSSLParameters();
+    sslParameters.setMaximumPacketSize(8192);
+    sslParameters.setEnableRetransmissions(true);
+    sslEngine.setSSLParameters(sslParameters);
   }
 
   public void close(SocketAddress clientId) {

--- a/src/main/java/io/mapsmessaging/network/io/impl/dtls/DTLSSessionManager.java
+++ b/src/main/java/io/mapsmessaging/network/io/impl/dtls/DTLSSessionManager.java
@@ -94,7 +94,6 @@ public class DTLSSessionManager implements Closeable, SelectorCallback {
       int mtu = 8192;
       paras.setMaximumPacketSize(mtu);
       paras.setEnableRetransmissions(true);
-      paras.setNeedClientAuth(false);
       sslEngine.setSSLParameters(paras);
       stateEngine = new StateEngine(packet.getFromAddress(), sslEngine, this);
       endPoint = new DTLSEndPoint(this, uniqueId.incrementAndGet(), packet.getFromAddress(), server, stateEngine, managerMBean);

--- a/src/main/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPoint.java
+++ b/src/main/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPoint.java
@@ -231,7 +231,7 @@ public class SSLEndPoint extends TCPEndPoint {
 
   @Override
   public Principal getEndPointPrincipal() {
-    if (sslEngine.getNeedClientAuth()) {
+    if (sslEngine.getNeedClientAuth() || sslEngine.getWantClientAuth()) {
       try {
         return sslEngine.getSession().getPeerPrincipal();
       } catch (SSLPeerUnverifiedException e) {

--- a/src/main/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPointConnectionFactory.java
+++ b/src/main/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPointConnectionFactory.java
@@ -33,6 +33,7 @@ import io.mapsmessaging.security.ssl.SslHelper;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
@@ -49,14 +50,28 @@ public class SSLEndPointConnectionFactory implements EndPointConnectionFactory {
       throws IOException {
     TlsConfig securityProps = (TlsConfig) endPointServerStatus.getConfig().getEndPointConfig();
     SSLContext context = SslHelper.createContext(securityProps.getSslConfig().getContext(),((Config) securityProps.getSslConfig()).toConfigurationProperties(), logger);
-    SSLEngine engine = SslHelper.createSSLEngine(context, ((Config)securityProps.getSslConfig()).toConfigurationProperties());
-    engine.setUseClientMode(true);
+    SSLEngine engine = createClientEngine(
+        context,
+        url.getHost(),
+        url.getPort(),
+        securityProps.getSslConfig().isHostnameVerificationEnabled());
     SocketChannel channel = SocketChannel.open();
     InetSocketAddress address = new InetSocketAddress(url.getHost(), url.getPort());
     channel.configureBlocking(true);
     channel.connect(address);
     channel.configureBlocking(false);
     return new SSLEndPoint(generateID(), engine, channel, selector.allocate(), callback, endPointServerStatus, jmxPath);
+  }
+
+  static SSLEngine createClientEngine(SSLContext context, String host, int port, boolean hostnameVerificationEnabled) {
+    SSLEngine engine = context.createSSLEngine(host, port);
+    engine.setUseClientMode(true);
+    if (hostnameVerificationEnabled) {
+      SSLParameters sslParameters = engine.getSSLParameters();
+      sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+      engine.setSSLParameters(sslParameters);
+    }
+    return engine;
   }
 
   @Override

--- a/src/main/resources/NetworkManager.yaml
+++ b/src/main/resources/NetworkManager.yaml
@@ -87,10 +87,11 @@ NetworkManager:
         tls:
           clientCertificateRequired: false
           clientCertificateWanted: false
+          hostnameVerificationEnabled: true
             #-----------------------------------
             # CRL Specific
             # crlUrl: <URL TO CRL>
-            # crlInterval: <time in seconds to reload CRL>
+            # crlInterval: <time in milliseconds to reload CRL>
             #-----------------------------------
 
           keyStore:

--- a/src/test/java/io/mapsmessaging/config/NetworkManagerConfigTest.java
+++ b/src/test/java/io/mapsmessaging/config/NetworkManagerConfigTest.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.config;
+
+import io.mapsmessaging.config.network.EndPointServerConfig;
+import io.mapsmessaging.config.network.impl.TlsConfig;
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class NetworkManagerConfigTest {
+
+  @Test
+  void endpoint_update_changes_the_stored_tls_configuration() {
+    EndPointServerConfig storedConfig = new EndPointServerConfig(createEndpoint(false));
+    EndPointServerConfig update = new EndPointServerConfig(createEndpoint(true));
+    NetworkManagerConfig networkManagerConfig = new NetworkManagerConfig();
+    networkManagerConfig.setEndPointServerConfigList(new ArrayList<>(List.of(storedConfig)));
+
+    Assertions.assertTrue(networkManagerConfig.update(update));
+
+    TlsConfig storedTlsConfig = (TlsConfig) storedConfig.getEndPointConfig();
+    Assertions.assertTrue(storedTlsConfig.getSslConfig().isClientCertificateRequired());
+  }
+
+  private ConfigurationProperties createEndpoint(boolean clientCertificateRequired) {
+    ConfigurationProperties keyStore = createStore("test-keystore.jks");
+    ConfigurationProperties trustStore = createStore("test-truststore.jks");
+
+    ConfigurationProperties tls = new ConfigurationProperties();
+    tls.put("context", "TLSv1.3");
+    tls.put("clientCertificateRequired", clientCertificateRequired);
+    tls.put("clientCertificateWanted", false);
+    tls.put("hostnameVerificationEnabled", true);
+    tls.put("keyStore", keyStore);
+    tls.put("trustStore", trustStore);
+
+    ConfigurationProperties security = new ConfigurationProperties();
+    security.put("tls", tls);
+
+    ConfigurationProperties config = new ConfigurationProperties();
+    config.put("name", "TLS endpoint");
+    config.put("url", "ssl://localhost:8883");
+    config.put("auth", "default");
+    config.put("protocol", "loop");
+    config.put("security", security);
+    return config;
+  }
+
+  private ConfigurationProperties createStore(String path) {
+    ConfigurationProperties store = new ConfigurationProperties();
+    store.put("type", "JKS");
+    store.put("managerFactory", "SunX509");
+    store.put("path", path);
+    store.put("passphrase", "password");
+    return store;
+  }
+}

--- a/src/test/java/io/mapsmessaging/config/network/impl/TlsSecurityConfigTest.java
+++ b/src/test/java/io/mapsmessaging/config/network/impl/TlsSecurityConfigTest.java
@@ -60,12 +60,12 @@ class TlsSecurityConfigTest {
   void dtls_update_applies_nested_ssl_settings() {
     DtlsConfig dtlsConfig = new DtlsConfig(createConfig());
     DtlsConfigDTO update = new DtlsConfigDTO();
-    SslConfigDTO sslUpdate = createSslUpdate("DTLSv1.3");
+    SslConfigDTO sslUpdate = createSslUpdate("DTLSv1.2");
     update.setSslConfig(sslUpdate);
 
     Assertions.assertTrue(dtlsConfig.update(update));
     Assertions.assertTrue(dtlsConfig.getSslConfig().isClientCertificateRequired());
-    Assertions.assertEquals("DTLSv1.3", dtlsConfig.getSslConfig().getContext());
+    Assertions.assertEquals("DTLSv1.2", dtlsConfig.getSslConfig().getContext());
     Assertions.assertEquals(7200000L, dtlsConfig.getSslConfig().getCrlInterval());
   }
 

--- a/src/test/java/io/mapsmessaging/config/network/impl/TlsSecurityConfigTest.java
+++ b/src/test/java/io/mapsmessaging/config/network/impl/TlsSecurityConfigTest.java
@@ -1,0 +1,118 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.config.network.impl;
+
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.dto.rest.config.network.SslConfigDTO;
+import io.mapsmessaging.dto.rest.config.network.impl.DtlsConfigDTO;
+import io.mapsmessaging.dto.rest.config.network.impl.TlsConfigDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TlsSecurityConfigTest {
+
+  @Test
+  void tls_and_dtls_load_their_own_security_profiles() {
+    ConfigurationProperties config = createConfig();
+
+    TlsConfig tlsConfig = new TlsConfig(config);
+    DtlsConfig dtlsConfig = new DtlsConfig(config);
+
+    Assertions.assertFalse(tlsConfig.getSslConfig().isClientCertificateRequired());
+    Assertions.assertEquals("TLSv1.3", tlsConfig.getSslConfig().getContext());
+    Assertions.assertTrue(tlsConfig.getSslConfig().isHostnameVerificationEnabled());
+    Assertions.assertTrue(dtlsConfig.getSslConfig().isClientCertificateRequired());
+    Assertions.assertEquals("DTLSv1.2", dtlsConfig.getSslConfig().getContext());
+  }
+
+  @Test
+  void tls_update_applies_nested_ssl_settings() {
+    TlsConfig tlsConfig = new TlsConfig(createConfig());
+    TlsConfigDTO update = new TlsConfigDTO();
+    SslConfigDTO sslUpdate = createSslUpdate("TLSv1.2");
+    update.setSslConfig(sslUpdate);
+
+    Assertions.assertTrue(tlsConfig.update(update));
+    Assertions.assertTrue(tlsConfig.getSslConfig().isClientCertificateRequired());
+    Assertions.assertFalse(tlsConfig.getSslConfig().isHostnameVerificationEnabled());
+    Assertions.assertEquals("TLSv1.2", tlsConfig.getSslConfig().getContext());
+    Assertions.assertEquals("https://example.test/tls.crl", tlsConfig.getSslConfig().getCrlUrl());
+  }
+
+  @Test
+  void dtls_update_applies_nested_ssl_settings() {
+    DtlsConfig dtlsConfig = new DtlsConfig(createConfig());
+    DtlsConfigDTO update = new DtlsConfigDTO();
+    SslConfigDTO sslUpdate = createSslUpdate("DTLSv1.3");
+    update.setSslConfig(sslUpdate);
+
+    Assertions.assertTrue(dtlsConfig.update(update));
+    Assertions.assertTrue(dtlsConfig.getSslConfig().isClientCertificateRequired());
+    Assertions.assertEquals("DTLSv1.3", dtlsConfig.getSslConfig().getContext());
+    Assertions.assertEquals(7200000L, dtlsConfig.getSslConfig().getCrlInterval());
+  }
+
+  private SslConfigDTO createSslUpdate(String context) {
+    SslConfigDTO sslConfig = new SslConfigDTO();
+    sslConfig.setClientCertificateRequired(true);
+    sslConfig.setClientCertificateWanted(false);
+    sslConfig.setHostnameVerificationEnabled(false);
+    sslConfig.setContext(context);
+    sslConfig.setCrlUrl("https://example.test/tls.crl");
+    sslConfig.setCrlInterval(7200000L);
+    return sslConfig;
+  }
+
+  private ConfigurationProperties createConfig() {
+    ConfigurationProperties tls = createSecurityProfile("TLSv1.3", false);
+    tls.put("hostnameVerificationEnabled", true);
+    ConfigurationProperties dtls = createSecurityProfile("DTLSv1.2", true);
+
+    ConfigurationProperties security = new ConfigurationProperties();
+    security.put("tls", tls);
+    security.put("dtls", dtls);
+
+    ConfigurationProperties config = new ConfigurationProperties();
+    config.put("security", security);
+    return config;
+  }
+
+  private ConfigurationProperties createSecurityProfile(String context, boolean clientCertificateRequired) {
+    ConfigurationProperties keyStore = new ConfigurationProperties();
+    keyStore.put("type", "JKS");
+    keyStore.put("managerFactory", "SunX509");
+    keyStore.put("path", "test-keystore.jks");
+    keyStore.put("passphrase", "password");
+
+    ConfigurationProperties trustStore = new ConfigurationProperties();
+    trustStore.put("type", "JKS");
+    trustStore.put("managerFactory", "SunX509");
+    trustStore.put("path", "test-truststore.jks");
+    trustStore.put("passphrase", "password");
+
+    ConfigurationProperties profile = new ConfigurationProperties();
+    profile.put("context", context);
+    profile.put("clientCertificateRequired", clientCertificateRequired);
+    profile.put("clientCertificateWanted", false);
+    profile.put("keyStore", keyStore);
+    profile.put("trustStore", trustStore);
+    return profile;
+  }
+}

--- a/src/test/java/io/mapsmessaging/network/io/impl/dtls/DTLSSessionManagerTest.java
+++ b/src/test/java/io/mapsmessaging/network/io/impl/dtls/DTLSSessionManagerTest.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.network.io.impl.dtls;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DTLSSessionManagerTest {
+
+  @Test
+  void dtls_parameters_preserve_required_client_certificates() throws Exception {
+    SSLEngine sslEngine = createEngine();
+    sslEngine.setNeedClientAuth(true);
+
+    DTLSSessionManager.configureEngine(sslEngine);
+
+    Assertions.assertTrue(sslEngine.getNeedClientAuth());
+  }
+
+  @Test
+  void dtls_parameters_preserve_wanted_client_certificates() throws Exception {
+    SSLEngine sslEngine = createEngine();
+    sslEngine.setWantClientAuth(true);
+
+    DTLSSessionManager.configureEngine(sslEngine);
+
+    Assertions.assertTrue(sslEngine.getWantClientAuth());
+  }
+
+  private SSLEngine createEngine() throws Exception {
+    SSLContext context = SSLContext.getInstance("DTLS");
+    context.init(null, null, null);
+    return context.createSSLEngine();
+  }
+}

--- a/src/test/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPointConnectionFactoryTest.java
+++ b/src/test/java/io/mapsmessaging/network/io/impl/ssl/SSLEndPointConnectionFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.network.io.impl.ssl;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SSLEndPointConnectionFactoryTest {
+
+  @Test
+  void outbound_engine_enables_hostname_verification_by_default() throws Exception {
+    SSLContext context = SSLContext.getInstance("TLS");
+    context.init(null, null, null);
+
+    SSLEngine sslEngine = SSLEndPointConnectionFactory.createClientEngine(context, "broker.example", 8883, true);
+
+    Assertions.assertTrue(sslEngine.getUseClientMode());
+    Assertions.assertEquals("broker.example", sslEngine.getPeerHost());
+    Assertions.assertEquals(8883, sslEngine.getPeerPort());
+    Assertions.assertEquals("HTTPS", sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm());
+  }
+
+  @Test
+  void outbound_engine_can_disable_hostname_verification() throws Exception {
+    SSLContext context = SSLContext.getInstance("TLS");
+    context.init(null, null, null);
+
+    SSLEngine sslEngine = SSLEndPointConnectionFactory.createClientEngine(context, "broker.example", 8883, false);
+
+    Assertions.assertNull(sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm());
+  }
+}


### PR DESCRIPTION
## Summary

- load DTLS endpoints from `security.dtls` and TLS endpoints from `security.tls`
- preserve configured DTLS client-certificate requirements
- expose peer certificate identities for required and requested TLS/DTLS authentication
- verify outbound TLS hostnames by default, with `hostnameVerificationEnabled` as an explicit opt-out
- apply nested TLS/DTLS settings during dynamic updates and update stored endpoint state
- serialize context, CRL, hostname, and key/trust-store settings consistently
- add focused configuration, DTLS, update-path, and outbound-engine regression tests

## Companion change

SSL engine and CRL trust-manager fixes: Maps-Messaging/authentication_library#464

## Verification

Focused JUnit tests were added for profile selection, nested updates, stored-state updates, DTLS client-auth preservation, and hostname verification. The available GitHub Maven workflow is running against the branch; no full local build is available in this managed environment.

SECURITY: TLS and DTLS transport hardening