### PR TITLE
fix(network): enforce RFC-compliant SASL authentication

### DIFF
--- a/src/main/java/io/mapsmessaging/dto/rest/config/auth/SaslConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/config/auth/SaslConfigDTO.java
@@ -45,8 +45,8 @@ public class SaslConfigDTO extends BaseConfigDTO {
   protected String realmName;
 
   @Schema(
-      description = "The SASL mechanism, such as PLAIN or SCRAM-SHA-256",
-      example = "PLAIN",
+      description = "The SASL mechanism: SCRAM-SHA-256, or PLAIN on SSL, DTLS, or WSS endpoints",
+      example = "SCRAM-SHA-256",
       requiredMode = Schema.RequiredMode.REQUIRED,
       nullable = false
 

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/amqp/proton/ProtonEngine.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/amqp/proton/ProtonEngine.java
@@ -76,11 +76,15 @@ public class ProtonEngine {
     }
   }
 
-  public void close() {
-    transport.close();
-    connection.close();
-    subscriptions.close();
-    engineScheduler = null;
+  public void close() throws IOException {
+    try {
+      saslManager.close();
+    } finally {
+      transport.close();
+      connection.close();
+      subscriptions.close();
+      engineScheduler = null;
+    }
   }
 
   public void processPacket(Packet packet) throws IOException {

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/amqp/proton/SaslManager.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/amqp/proton/SaslManager.java
@@ -48,6 +48,9 @@ public class SaslManager {
   }
 
   public void challenge() throws IOException {
+    if (saslAuthenticationMechanism == null) {
+      return;
+    }
     int pending = Math.max(0, sasl.pending());
     byte[] challenge;
     if (pending > 0) {
@@ -85,6 +88,12 @@ public class SaslManager {
     }
 
     return saslAuthenticationMechanism == null || sasl.getOutcome().equals(Sasl.SaslOutcome.PN_SASL_OK);
+  }
+
+  public void close() throws IOException {
+    if (saslAuthenticationMechanism != null) {
+      saslAuthenticationMechanism.close();
+    }
   }
 
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt5/AuthenticationContext.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt5/AuthenticationContext.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AuthenticationContext {
+public class AuthenticationContext implements AutoCloseable {
 
   @Getter
   @Setter
@@ -64,5 +64,10 @@ public class AuthenticationContext {
 
   public String getUsername() {
     return mechanism.getUsername();
+  }
+
+  @Override
+  public void close() throws IOException {
+    mechanism.close();
   }
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt5/MQTT5Protocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt5/MQTT5Protocol.java
@@ -170,15 +170,22 @@ public class MQTT5Protocol extends Protocol {
 
   @Override
   public void close() throws IOException {
-    if(selectorTask.isOpen()){
-      selectorTask.close();
-    }
-    if(session != null && !session.isClosed()){
-      SessionManager.getInstance().close(session, false);
-    }
-    if (!closed) {
-      closed = true;
-      super.close();
+    try {
+      if (authenticationContext != null) {
+        authenticationContext.close();
+      }
+    } finally {
+      authenticationContext = null;
+      if(selectorTask.isOpen()){
+        selectorTask.close();
+      }
+      if(session != null && !session.isClosed()){
+        SessionManager.getInstance().close(session, false);
+      }
+      if (!closed) {
+        closed = true;
+        super.close();
+      }
     }
   }
 

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt5/listeners/AuthListener5.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt5/listeners/AuthListener5.java
@@ -45,7 +45,7 @@ public class AuthListener5 extends PacketListener5 {
       MQTT5Protocol mqtt5Protocol = ((MQTT5Protocol) protocol);
       AuthenticationMethod authMethod = (AuthenticationMethod) mqttPacket.getProperties().get(MessagePropertyFactory.AUTHENTICATION_METHOD);
       if (mqtt5Protocol.getAuthenticationContext() != null && authMethod != null) {
-        if (!mqtt5Protocol.getAuthenticationContext().getAuthMethod().equalsIgnoreCase(authMethod.getAuthenticationMethod())) {
+        if (!mqtt5Protocol.getAuthenticationContext().getAuthMethod().equals(authMethod.getAuthenticationMethod())) {
           return rejectAuth(authMethod, protocol);
         }
         context = mqtt5Protocol.getAuthenticationContext();
@@ -83,6 +83,9 @@ public class AuthListener5 extends PacketListener5 {
 
   private MQTTPacket5 handleAuth(AuthenticationContext context, Protocol protocol, MQTTPacket5 mqttPacket, Session session, EndPoint endPoint) throws MalformedException {
       AuthenticationData clientData = (AuthenticationData) mqttPacket.getProperties().get(MessagePropertyFactory.AUTHENTICATION_DATA);
+      if (clientData == null) {
+        throw new MalformedException("Authentication Data is required for SASL authentication");
+      }
       byte[] clientChallenge;
       try {
         clientChallenge = context.evaluateResponse(clientData.getAuthenticationData());

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt_sn/v2_0/MQTT_SNProtocolV2.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/mqtt_sn/v2_0/MQTT_SNProtocolV2.java
@@ -79,9 +79,16 @@ public class MQTT_SNProtocolV2 extends MQTT_SNProtocol {
   @Override
   public void close() throws IOException {
     if (!closed) {
-      logger.log(ServerLogMessages.MQTT_SN_CLOSED);
-      closed = true;
-      finish();
+      try {
+        if (saslAuthenticationMechanism != null) {
+          saslAuthenticationMechanism.close();
+        }
+      } finally {
+        saslAuthenticationMechanism = null;
+        logger.log(ServerLogMessages.MQTT_SN_CLOSED);
+        closed = true;
+        finish();
+      }
     }
   }
 

--- a/src/main/java/io/mapsmessaging/network/protocol/sasl/SaslAuthenticationMechanism.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/sasl/SaslAuthenticationMechanism.java
@@ -30,16 +30,27 @@ import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
-public class SaslAuthenticationMechanism implements AuthenticationMechanism {
+public class SaslAuthenticationMechanism implements AuthenticationMechanism, AutoCloseable {
+
+  static final String SCRAM_SHA_256 = "SCRAM-SHA-256";
+  static final String PLAIN = "PLAIN";
+  private static final int MAX_CHALLENGES = 4;
 
   private final SaslServer saslServer;
+  private int challengeCount;
+  private String username;
+  private boolean closed;
 
   @Getter
   private final String mechanism;
 
   public SaslAuthenticationMechanism(String mechanism, String serverName, String protocol, Map<String, String> props, EndPointServerConfigDTO properties) throws IOException {
+    validateMechanism(mechanism, properties);
     SaslConfigDTO saslConfig = properties.getSaslConfig();
     IdentityLookup identityLookup;
     ServerCallbackHandler serverCallbackHandler;
@@ -52,16 +63,32 @@ public class SaslAuthenticationMechanism implements AuthenticationMechanism {
       throw new SaslException("Unable to locate identity look up mechanism for " + saslConfig.getSaslEntries());
     }
     serverCallbackHandler = new ServerCallbackHandler(serverName, identityLookup);
-    saslServer = Sasl.createSaslServer(mechanism, protocol, serverName, props, serverCallbackHandler);
+    Map<String, String> effectiveProperties = props == null ? new HashMap<>() : new HashMap<>(props);
+    if (!PLAIN.equals(mechanism)) {
+      effectiveProperties.put(Sasl.POLICY_NOPLAINTEXT, Boolean.TRUE.toString());
+    }
+    saslServer = Sasl.createSaslServer(mechanism, protocol, serverName, effectiveProperties, serverCallbackHandler);
     if (saslServer == null) {
       throw new IOException("Unsupported Sasl Mechanism : " + mechanism);
     }
     this.mechanism = mechanism;
+    challengeCount = 0;
+    closed = false;
   }
 
   @Override
   public byte[] challenge(byte[] challenge) throws IOException {
-    return saslServer.evaluateResponse(challenge);
+    if (closed) {
+      throw new SaslException("SASL authentication is closed");
+    }
+    if (++challengeCount > MAX_CHALLENGES) {
+      throw new SaslException("SASL authentication exceeded the permitted number of exchanges");
+    }
+    byte[] response = saslServer.evaluateResponse(challenge == null ? new byte[0] : challenge);
+    if (saslServer.isComplete()) {
+      username = saslServer.getAuthorizationID();
+    }
+    return response;
   }
 
   @Override
@@ -77,9 +104,46 @@ public class SaslAuthenticationMechanism implements AuthenticationMechanism {
   }
 
   public String getUsername() {
-    if(saslServer.isComplete()) {
-      return saslServer.getAuthorizationID();
+    return username;
+  }
+
+  @Override
+  public void close() throws SaslException {
+    if (!closed) {
+      saslServer.dispose();
+      closed = true;
     }
-    return null;
+  }
+
+  static boolean isSupportedMechanism(String mechanism) {
+    return SCRAM_SHA_256.equals(mechanism) || PLAIN.equals(mechanism);
+  }
+
+  static boolean isProtectedTransport(String url) {
+    if (url == null) {
+      return false;
+    }
+    String scheme;
+    try {
+      scheme = URI.create(url).getScheme();
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+    if (scheme == null) {
+      return false;
+    }
+    return switch (scheme.toLowerCase(Locale.ROOT)) {
+      case "ssl", "dtls", "wss" -> true;
+      default -> false;
+    };
+  }
+
+  private void validateMechanism(String mechanism, EndPointServerConfigDTO properties) throws SaslException {
+    if (!isSupportedMechanism(mechanism)) {
+      throw new SaslException("Unsupported SASL mechanism: " + mechanism);
+    }
+    if (PLAIN.equals(mechanism) && !isProtectedTransport(properties.getUrl())) {
+      throw new SaslException("PLAIN SASL requires SSL, DTLS, or WSS transport");
+    }
   }
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/sasl/ServerCallbackHandler.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/sasl/ServerCallbackHandler.java
@@ -31,6 +31,7 @@ import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Objects;
 
 public class ServerCallbackHandler implements CallbackHandler {
 
@@ -50,7 +51,11 @@ public class ServerCallbackHandler implements CallbackHandler {
     for (Callback cb : cbs) {
       if (cb instanceof AuthorizeCallback) {
         AuthorizeCallback ac = (AuthorizeCallback) cb;
-        ac.setAuthorized(true);
+        boolean authorized = Objects.equals(ac.getAuthenticationID(), ac.getAuthorizationID());
+        ac.setAuthorized(authorized);
+        if (authorized) {
+          ac.setAuthorizedID(ac.getAuthorizationID());
+        }
       } else if (cb instanceof NameCallback) {
         NameCallback nc = (NameCallback) cb;
         username = nc.getDefaultName();
@@ -61,6 +66,9 @@ public class ServerCallbackHandler implements CallbackHandler {
         }
         nc.setName(nc.getDefaultName());
       } else if (cb instanceof PasswordCallback) {
+        if (hashedPassword == null) {
+          throw new IOException("Password requested before an identity was resolved");
+        }
         PasswordCallback pc = (PasswordCallback) cb;
         pc.setPassword(hashedPassword.getHash());
       } else if (cb instanceof RealmCallback) {

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/MQTTBaseTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/MQTTBaseTest.java
@@ -86,15 +86,15 @@ public class MQTTBaseTest extends BaseTestConfig {
   }
 
   public SaslClient setForSasl(MqttConnectionOptions options, String username, String password) throws IOException {
-    String mechanism = "CRAM-MD5";
+    String mechanism = "SCRAM-SHA-256";
     Map<String, String> props = new HashMap<>();
     props.put(Sasl.QOP, "auth");
     String[] mechanisms = {mechanism};
     ClientCallbackHandler clientHandler = new ClientCallbackHandler(username, password, "servername");
-    SaslClient saslClient = Sasl.createSaslClient(mechanisms, "authorizationId", "MQTT", "serverName", props, clientHandler);
+    SaslClient saslClient = Sasl.createSaslClient(mechanisms, null, "MQTT", "serverName", props, clientHandler);
     if (options != null) {
       options.setAuthMethod(mechanism);
-      options.setAuthData(new byte[0]);
+      options.setAuthData(saslClient.evaluateChallenge(new byte[0]));
     }
     return saslClient;
   }

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/MqttAuthSaslTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/MqttAuthSaslTest.java
@@ -36,12 +36,9 @@ import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckReasonCo
 import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import io.mapsmessaging.security.MapsSecurityProvider;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.KeyStore;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -50,7 +47,6 @@ import javax.net.ssl.*;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
-import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -123,9 +119,9 @@ class MqttAuthSaslTest extends MQTTBaseTest {
   @ParameterizedTest
   @MethodSource("mqttGetAuthUrls")
   void testInvalidMechanism(int version, String protocol) throws Exception {
-    SaslClient saslClient = badMechanism(null, "admin", "Bad Password");
+    SaslClient saslClient = setForSasl(null, "admin", "Bad Password");
     boolean isSsl = protocol.equalsIgnoreCase("ssl") || protocol.equalsIgnoreCase("wss");
-    Mqtt5EnhancedAuthMechanism mqtt5EnhancedAuthMechanism = new Mqtt5SaslAuth(saslClient);
+    Mqtt5EnhancedAuthMechanism mqtt5EnhancedAuthMechanism = new Mqtt5SaslAuth(saslClient, true);
     Mqtt5ClientBuilder builder = MqttClient.builder()
         .useMqttVersion5()
         .enhancedAuth(mqtt5EnhancedAuthMechanism)
@@ -180,20 +176,6 @@ class MqttAuthSaslTest extends MQTTBaseTest {
         .build();
   }
 
-  public SaslClient badMechanism(MqttConnectionOptions options, String username, String password) throws IOException {
-    String mechanism = "SCRAM-SHA-512";
-    Map<String, String> props = new HashMap<>();
-    props.put(Sasl.QOP, "auth");
-    String[] mechanisms = {mechanism};
-    ClientCallbackHandler clientHandler = new ClientCallbackHandler(username, password, "servername");
-    SaslClient saslClient = Sasl.createSaslClient(mechanisms, "authorizationId", "MQTT", "serverName", props, clientHandler);
-    if (options != null) {
-      options.setAuthMethod(mechanism);
-      options.setAuthData(new byte[0]);
-    }
-    return saslClient;
-  }
-
   private static class Mqtt5SaslAuth implements Mqtt5EnhancedAuthMechanism {
 
     private final SaslClient saslClient;
@@ -225,8 +207,12 @@ class MqttAuthSaslTest extends MQTTBaseTest {
 
     @Override
     public @NotNull CompletableFuture<Void> onAuth(@NotNull Mqtt5ClientConfig mqtt5ClientConfig, @NotNull Mqtt5Connect mqtt5Connect, @NotNull Mqtt5EnhancedAuthBuilder mqtt5EnhancedAuthBuilder) {
-      mqtt5EnhancedAuthBuilder.data(new byte[0]);
-      return CompletableFuture.completedFuture(null);
+      try {
+        mqtt5EnhancedAuthBuilder.data(saslClient.evaluateChallenge(new byte[0]));
+        return CompletableFuture.completedFuture(null);
+      } catch (SaslException e) {
+        return CompletableFuture.failedFuture(e);
+      }
     }
 
     @Override

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt_sn/MqttSnAuthTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt_sn/MqttSnAuthTest.java
@@ -43,10 +43,10 @@ class MqttSnAuthTest extends BaseMqttSnConfig {
   void simpleAuthValidation() throws MqttsnException, MqttsnClientConnectException, IOException, MqttsnQueueAcceptException {
     Map<String, String> props = new HashMap<>();
     props.put(Sasl.QOP, "auth");
-    String mechanisms = "SCRAM-SHA-512";
+    String mechanisms = "SCRAM-SHA-256";
     ClientCallbackHandler clientHandler = new ClientCallbackHandler("admin", getPassword("admin"), "servername");
 
-    IAuthHandler authHandler = new SaslAuthHandler(mechanisms, "Authorized", "localhost", props, clientHandler);
+    IAuthHandler authHandler = new SaslAuthHandler(mechanisms, null, "localhost", props, clientHandler);
     MqttSnClient client = new MqttSnClient( "localhost", 1887, 2, authHandler);
     client.connect(50, true);
     Assertions.assertTrue(client.isConnected());

--- a/src/test/java/io/mapsmessaging/network/protocol/sasl/SaslAuthenticationMechanismTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/sasl/SaslAuthenticationMechanismTest.java
@@ -1,0 +1,51 @@
+/*
+ *
+ * Copyright [ 2020 - 2024 ] Matthew Buckton
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.network.protocol.sasl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SaslAuthenticationMechanismTest {
+
+  @Test
+  void supported_mechanisms_are_explicitly_allowlisted() {
+    assertTrue(SaslAuthenticationMechanism.isSupportedMechanism("SCRAM-SHA-256"));
+    assertTrue(SaslAuthenticationMechanism.isSupportedMechanism("PLAIN"));
+    assertFalse(SaslAuthenticationMechanism.isSupportedMechanism("SCRAM-SHA-1"));
+    assertFalse(SaslAuthenticationMechanism.isSupportedMechanism("SCRAM-SHA-512"));
+    assertFalse(SaslAuthenticationMechanism.isSupportedMechanism("DIGEST-MD5"));
+    assertFalse(SaslAuthenticationMechanism.isSupportedMechanism("CRAM-MD5"));
+    assertFalse(SaslAuthenticationMechanism.isSupportedMechanism("plain"));
+  }
+
+  @Test
+  void plain_requires_a_protected_transport() {
+    assertTrue(SaslAuthenticationMechanism.isProtectedTransport("ssl://localhost:8883"));
+    assertTrue(SaslAuthenticationMechanism.isProtectedTransport("dtls://localhost:1884"));
+    assertTrue(SaslAuthenticationMechanism.isProtectedTransport("wss://localhost:9443/mqtt"));
+    assertFalse(SaslAuthenticationMechanism.isProtectedTransport("tcp://localhost:1883"));
+    assertFalse(SaslAuthenticationMechanism.isProtectedTransport("udp://localhost:1884"));
+    assertFalse(SaslAuthenticationMechanism.isProtectedTransport("ws://localhost:8080/mqtt"));
+    assertFalse(SaslAuthenticationMechanism.isProtectedTransport("not a url"));
+    assertFalse(SaslAuthenticationMechanism.isProtectedTransport(null));
+  }
+}

--- a/src/test/java/io/mapsmessaging/network/protocol/sasl/ServerCallbackHandlerTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/sasl/ServerCallbackHandlerTest.java
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright [ 2020 - 2024 ] Matthew Buckton
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.network.protocol.sasl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.sasl.AuthorizeCallback;
+import org.junit.jupiter.api.Test;
+
+class ServerCallbackHandlerTest {
+
+  @Test
+  void authorization_identity_must_match_authentication_identity() throws Exception {
+    ServerCallbackHandler callbackHandler = new ServerCallbackHandler("server", null);
+    AuthorizeCallback sameIdentity = new AuthorizeCallback("matthew", "matthew");
+    AuthorizeCallback delegatedIdentity = new AuthorizeCallback("matthew", "administrator");
+
+    callbackHandler.handle(new Callback[] {sameIdentity, delegatedIdentity});
+
+    assertTrue(sameIdentity.isAuthorized());
+    assertEquals("matthew", sameIdentity.getAuthorizedID());
+    assertFalse(delegatedIdentity.isAuthorized());
+  }
+
+  @Test
+  void password_callback_requires_a_resolved_identity() {
+    ServerCallbackHandler callbackHandler = new ServerCallbackHandler("server", null);
+    assertThrows(IOException.class, () -> callbackHandler.handle(new Callback[] {new PasswordCallback("password", false)}));
+  }
+}

--- a/src/test/resources/NetworkManager.yaml
+++ b/src/test/resources/NetworkManager.yaml
@@ -160,7 +160,7 @@ NetworkManager:
         protocol: mqtt, ws
         auth: public
         sasl:
-          mechanism: "CRAM-MD5"
+          mechanism: "SCRAM-SHA-256"
           identityProvider: system
 
       - name: "MQTT SSL Test Auth Interface"
@@ -168,7 +168,7 @@ NetworkManager:
         protocol: mqtt, ws
         auth: public
         sasl:
-          mechanism: "CRAM-MD5"
+          mechanism: "SCRAM-SHA-256"
           identityProvider: system
 
       - name: "Stomp Interface - Anonymous Stomp over TCP"
@@ -210,14 +210,14 @@ NetworkManager:
         url: "tcp://0.0.0.0:5674/"
         protocol: amqp
         sasl:
-          mechanism: SCRAM-SHA-512
+          mechanism: SCRAM-SHA-256
           identityProvider: system
 
       - name: "AMQP Authenticated over ssl Interface"
         url: "ssl://0.0.0.0:5693/"
         protocol: amqp
         sasl:
-          mechanism: SCRAM-SHA-512
+          mechanism: SCRAM-SHA-256
           identityProvider: system
 
       -
@@ -283,7 +283,7 @@ NetworkManager:
             topic: predefined/topic
             address: '*'
         sasl:
-          mechanism: SCRAM-SHA-512
+          mechanism: SCRAM-SHA-256
           identityProvider: system
 
 


### PR DESCRIPTION
## Summary

- allowlist `SCRAM-SHA-256` and `PLAIN` at the server boundary
- require SSL, DTLS, or WSS before accepting PLAIN
- require exact MQTT enhanced-auth method names and client-first authentication data
- enforce authorization identity equality, exchange limits, and post-close rejection
- dispose SASL state from MQTT 5, MQTT-SN 2, and AMQP protocol lifecycles
- migrate server test clients and endpoint configuration from CRAM-MD5/SCRAM-SHA-512 to SCRAM-SHA-256

## Tests

- server mechanism allowlist and protected-transport policy
- callback ordering and authorization identity rejection
- existing MQTT 5 and MQTT-SN integration clients updated for client-first SCRAM-SHA-256
- focused Java 21 compilation of the SASL boundary
- end-to-end SCRAM-SHA-256 and protected PLAIN exchanges through the server wrapper

Depends on Maps-Messaging/authentication_library#465.

Full Maven resolution was unavailable in the managed environment because the project depends on Maps/private build artifacts.