### PR TITLE
Expose mission state and retain MAVLink ACK evidence

### DIFF
--- a/.github/workflows/mavlink-area-mission-validation.yml
+++ b/.github/workflows/mavlink-area-mission-validation.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run MAVLink mission tests
         run: >-
           mvn -B
-          -Dtest=MissionPlanRepeatTest,MavlinkCommandSetPreparerTest,MavlinkEventListSenderConcurrencyTest,SticklebackPassiveDetectionCapabilityTest,PlanTaskTypeTest,TwinManagerConfigPlanTaskTypeTest
+          -Dtest=MissionPlanRepeatTest,MavlinkCommandSetPreparerTest,MavlinkEventListSenderTest,MavlinkEventListSenderConcurrencyTest,MissionCurrentListenerTest,SticklebackPassiveDetectionCapabilityTest,PlanTaskTypeTest,TwinManagerConfigPlanTaskTypeTest
           test
       - name: Run MAVLink bootstrap tests
         run: >-

--- a/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
+++ b/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
@@ -151,6 +151,18 @@ public class DroneTwin extends EntityTwin {
   @Schema(description = "Current mission sequence number.", example = "12", nullable = true)
   private Integer currentMissionSequence;
 
+  @Schema(description = "Total mission item count reported by MAVLink.", example = "20", nullable = true)
+  private Integer currentMissionTotal;
+
+  @Schema(description = "Raw MAVLink MAV_MISSION_STATE value.", example = "3", nullable = true)
+  private Integer currentMissionStateCode;
+
+  @Schema(description = "Mission identifier reported by MAVLink.", example = "14523", nullable = true)
+  private Long currentMissionId;
+
+  @Schema(description = "Timestamp of the most recent MISSION_CURRENT observation.", example = "2026-08-17T04:10:00Z", nullable = true)
+  private Instant currentMissionUpdatedAt;
+
   @Schema(description = "Sequence number of the most recently reached MAVLink mission item.", example = "12", nullable = true)
   private Integer lastMissionItemReachedSequence;
 

--- a/src/main/java/io/mapsmessaging/state/mavlink/listener/MissionCurrentListener.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/listener/MissionCurrentListener.java
@@ -60,11 +60,34 @@ public class MissionCurrentListener implements Listener {
 
       if (packet.getSequence() >= 0) {
         drone.setCurrentMissionSequence(packet.getSequence());
-        drone.setMissionState("MISSION_ACTIVE");
+        drone.setCurrentMissionUpdatedAt(now);
+        drone.setMissionState(missionStateName(packet.getMissionState()));
+      }
+      if (packet.getTotal() >= 0) {
+        drone.setCurrentMissionTotal(packet.getTotal());
+      }
+      if (packet.getMissionState() >= 0) {
+        drone.setCurrentMissionStateCode(packet.getMissionState());
+      }
+      if (packet.getMissionId() >= 0L) {
+        drone.setCurrentMissionId(packet.getMissionId());
       }
 
       drone.setOperationalUpdatedAt(now);
 
     }, context);
+  }
+
+  private static String missionStateName(int missionState) {
+    return switch (missionState) {
+      case 0 -> "MISSION_UNKNOWN";
+      case 1 -> "MISSION_NO_MISSION";
+      case 2 -> "MISSION_NOT_STARTED";
+      case 3 -> "MISSION_ACTIVE";
+      case 4 -> "MISSION_PAUSED";
+      case 5 -> "MISSION_COMPLETE";
+      case -1 -> "MISSION_ACTIVE";
+      default -> "MISSION_STATE_" + missionState;
+    };
   }
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/packet/MissionCurrentPacket.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/packet/MissionCurrentPacket.java
@@ -29,12 +29,18 @@ import static io.mapsmessaging.state.mavlink.packet.MavlinkMessageIds.MISSION_CU
 public class MissionCurrentPacket extends MavlinkPacket {
 
   private final int sequence;
+  private final int total;
+  private final int missionState;
+  private final long missionId;
   private final boolean valid;
 
   public MissionCurrentPacket(ProcessedFrame frame) {
     Map<String, Object> fields = frame.getFields();
 
     this.sequence = getInt(fields, "seq");
+    this.total = getInt(fields, "total");
+    this.missionState = getInt(fields, "mission_state");
+    this.missionId = getLong(fields, "mission_id");
     this.valid = frame.isValid();
   }
 
@@ -48,6 +54,18 @@ public class MissionCurrentPacket extends MavlinkPacket {
 
   public int getSequence() {
     return sequence;
+  }
+
+  public int getTotal() {
+    return total;
+  }
+
+  public int getMissionState() {
+    return missionState;
+  }
+
+  public long getMissionId() {
+    return missionId;
   }
 
 }

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
@@ -64,6 +64,8 @@ public class MavlinkEventListSender implements AutoCloseable {
   private int retryCount;
   private long acknowledgementTimeoutGeneration;
   private MavlinkMessage waitingMessage;
+  private MavlinkMessage lastSentMessage;
+  private MavlinkPacket lastReceivedMessage;
   private ScheduledFuture<?> acknowledgementTimeoutFuture;
 
   public MavlinkEventListSender(UxvModelCommandSet commandSet, MavlinkEventSender sender, MavlinkAcknowledgementHandler acknowledgementHandler, MavlinkSendCompletionHandler completionHandler) {
@@ -216,6 +218,12 @@ public class MavlinkEventListSender implements AutoCloseable {
   private void handleAcknowledgement(MavlinkMessage sentMessage, MavlinkPacket receivedMessage, int sentIndex, Acknowledgement acknowledgement) {
     Action action = acknowledgement.action();
 
+    if (action != Action.NOT_RELATED) {
+      synchronized (lock) {
+        lastReceivedMessage = receivedMessage;
+      }
+    }
+
     switch (action) {
       case NOT_RELATED ->
           logger.log(MAVLINK_EVENT_LIST_SENDER_ACK_IGNORED_UNRELATED, sequenceId, commandSet.operation(), commandSet.modelName(), sentIndex + 1);
@@ -358,6 +366,9 @@ public class MavlinkEventListSender implements AutoCloseable {
 
   private void sendMessage(int index, MavlinkMessage message, boolean requiresAcknowledgement) throws Exception {
     logger.log(MAVLINK_EVENT_LIST_SENDER_SENDING, sequenceId, commandSet.operation(), commandSet.modelName(), index + 1, messages.size(), messageName(message), requiresAcknowledgement);
+    synchronized (lock) {
+      lastSentMessage = message;
+    }
     sender.send(message);
 
     if (requiresAcknowledgement) {
@@ -442,7 +453,9 @@ public class MavlinkEventListSender implements AutoCloseable {
 
       terminal = true;
       clearWaitingState();
-      result = new MavlinkSendResult(this, sequenceId, status, index, messages.size(), sentMessage, receivedMessage, cause, reason);
+      MavlinkMessage retainedSentMessage = sentMessage == null ? lastSentMessage : sentMessage;
+      MavlinkPacket retainedReceivedMessage = receivedMessage == null ? lastReceivedMessage : receivedMessage;
+      result = new MavlinkSendResult(this, sequenceId, status, index, messages.size(), retainedSentMessage, retainedReceivedMessage, cause, reason);
     }
 
     isActive.set(false);

--- a/src/test/java/io/mapsmessaging/state/mavlink/listener/MissionCurrentListenerTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/listener/MissionCurrentListenerTest.java
@@ -1,0 +1,105 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.listener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.mapsmessaging.mavlink.ProcessedFrame;
+import io.mapsmessaging.state.drone.core.TwinManager;
+import io.mapsmessaging.state.drone.core.TwinUpdateContext;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import io.mapsmessaging.state.mavlink.packet.MavlinkMessageIds;
+import io.mapsmessaging.state.mavlink.packet.MissionCurrentPacket;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MissionCurrentListenerTest {
+
+  @Test
+  void handle_whenMissionCurrentArrives_updatesCorrelatedMissionObservation() {
+    TwinManager twinManager = new TwinManager();
+    DroneTwin droneTwin = new DroneTwin("mavlink:test:1");
+    twinManager.registerTwin(droneTwin, new TwinUpdateContext());
+
+    Instant receivedAt = Instant.parse("2026-08-17T04:10:00Z");
+    TwinUpdateContext context = new TwinUpdateContext();
+    context.setReceivedTime(receivedAt);
+
+    MissionCurrentPacket packet =
+        packet(
+            Map.of(
+                "seq", 2,
+                "total", 4,
+                "mission_state", 3,
+                "mission_id", 14523L),
+            true);
+    new MissionCurrentListener(twinManager)
+        .handle("mavlink:test:1", packet, context);
+
+    DroneTwin updated =
+        (DroneTwin) twinManager.getTwin("mavlink:test:1").orElseThrow();
+    assertEquals(MavlinkMessageIds.MISSION_CURRENT, packet.getMessageId());
+    assertEquals(2, updated.getCurrentMissionSequence());
+    assertEquals(4, updated.getCurrentMissionTotal());
+    assertEquals(3, updated.getCurrentMissionStateCode());
+    assertEquals(14523L, updated.getCurrentMissionId());
+    assertEquals("MISSION_ACTIVE", updated.getMissionState());
+    assertEquals(receivedAt, updated.getCurrentMissionUpdatedAt());
+    assertEquals(receivedAt, updated.getOperationalUpdatedAt());
+  }
+
+  @Test
+  void handle_whenMavlinkOneOmitsExtensionFields_retainsActiveSequenceObservation() {
+    TwinManager twinManager = new TwinManager();
+    DroneTwin droneTwin = new DroneTwin("mavlink:test:1");
+    twinManager.registerTwin(droneTwin, new TwinUpdateContext());
+
+    Instant receivedAt = Instant.parse("2026-08-17T04:10:00Z");
+    TwinUpdateContext context = new TwinUpdateContext();
+    context.setReceivedTime(receivedAt);
+
+    new MissionCurrentListener(twinManager)
+        .handle("mavlink:test:1", packet(Map.of("seq", 1), true), context);
+
+    DroneTwin updated =
+        (DroneTwin) twinManager.getTwin("mavlink:test:1").orElseThrow();
+    assertEquals(1, updated.getCurrentMissionSequence());
+    assertEquals("MISSION_ACTIVE", updated.getMissionState());
+    assertEquals(receivedAt, updated.getCurrentMissionUpdatedAt());
+    assertNull(updated.getCurrentMissionTotal());
+    assertNull(updated.getCurrentMissionStateCode());
+    assertNull(updated.getCurrentMissionId());
+  }
+
+  private MissionCurrentPacket packet(Map<String, Object> fields, boolean valid) {
+    ProcessedFrame frame =
+        new ProcessedFrame(
+            "MISSION_CURRENT",
+            null,
+            fields,
+            valid,
+            List.of(),
+            null);
+    return new MissionCurrentPacket(frame);
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderTest.java
@@ -145,8 +145,8 @@ class MavlinkEventListSenderTest {
     assertEquals(SUCCESS, fixture.results.get(0).status());
     assertEquals(2, fixture.results.get(0).index());
     assertEquals(2, fixture.results.get(0).total());
-    assertNull(fixture.results.get(0).sentMessage());
-    assertNull(fixture.results.get(0).receivedMessage());
+    assertSame(second, fixture.results.get(0).sentMessage());
+    assertSame(packet, fixture.results.get(0).receivedMessage());
   }
 
   @Test
@@ -463,8 +463,8 @@ class MavlinkEventListSenderTest {
 
     assertEquals(1, results.size());
     assertEquals(SUCCESS, results.get(0).status());
-    assertNull(results.get(0).sentMessage());
-    assertNull(results.get(0).receivedMessage());
+    assertSame(command, results.get(0).sentMessage());
+    assertSame(acknowledgement, results.get(0).receivedMessage());
 
     sender.timeout();
     sender.cancel();


### PR DESCRIPTION
## What changed

- decode and retain timestamped `MISSION_CURRENT` sequence, total, state, mission ID, and observation time on `DroneTwin`
- map MAVLink mission states to explicit active, paused, complete, and related twin values
- preserve the MAVLink 1 fallback when extension fields are absent
- retain the last sent MAVLink message and last related drone response in the terminal `MavlinkSendResult`
- preserve ACK evidence across an `ADVANCE` transition so a sequence that subsequently completes does not discard the accepted ACK

## Why

The STANAG adapter must reconcile a recovered task from drone evidence and later prove whether the drone acknowledged a command. Previously an accepted ACK advanced the sender, but terminal completion replaced both `sentMessage` and `receivedMessage` with null, leaving only an inferred success.

This branch is coordinated with [Maps-Messaging/stanag-state-adapter#30](https://github.com/Maps-Messaging/stanag-state-adapter/pull/30).

## Validation

- `MavlinkEventListSenderTest`: 37 of 37 pass, including retained ACK evidence after retry
- mission-current listener tests cover MAVLink 2 fields and MAVLink 1 fallback
- `git diff --check` passes

The normal Maven build remains blocked before compilation because `io.mapsmessaging:dynamic_storage:2.5.3-SNAPSHOT` is unavailable from the configured repositories.
