### PR TITLE
test(session): enhance keep-alive tests with `FakeProtocol` and sessi…

### DIFF
--- a/src/test/java/io/mapsmessaging/api/SessionTest.java
+++ b/src/test/java/io/mapsmessaging/api/SessionTest.java
@@ -25,8 +25,10 @@ import io.mapsmessaging.api.features.QualityOfService;
 import io.mapsmessaging.api.message.Message;
 import io.mapsmessaging.engine.destination.subscription.SubscriptionContext;
 import io.mapsmessaging.engine.destination.subscription.SubscriptionController;
+import io.mapsmessaging.engine.session.FakeProtocol;
 import io.mapsmessaging.engine.session.ProtocolMessageListener;
 import io.mapsmessaging.engine.session.SessionManagerTest;
+import io.mapsmessaging.network.ProtocolClientConnection;
 import io.mapsmessaging.test.WaitForState;
 import java.util.Map;
 import java.util.Queue;
@@ -131,19 +133,45 @@ class SessionTest extends MessageAPITest implements ProtocolMessageListener {
   @Test
   @DisplayName("Simple session keep alive state")
   void sessionKeepAlive(TestInfo testInfo) throws Exception {
-    int initialCount = SessionManagerTest.getInstance().sessionCount();
+    String sessionName = testInfo.getTestMethod().get().getName();
     receivedKeepAlive.set(0);
-    Session session = createSession(testInfo.getTestMethod().get().getName(), 5, 12, true, this);
-    Assertions.assertEquals(initialCount+1, SessionManagerTest.getInstance().sessionCount());
-    WaitForState.waitFor(10, TimeUnit.SECONDS, () -> receivedKeepAlive.get() != 0);
-    Assertions.assertTrue(receivedKeepAlive.get() != 0);
-    receivedKeepAlive.set(0);
-    close(session);
-    Assertions.assertEquals(initialCount, SessionManagerTest.getInstance().sessionCount());
-    Assertions.assertTrue(SessionManagerTest.getInstance().hasIdleSessions());
-    WaitForState.waitFor(12, TimeUnit.SECONDS, () -> receivedKeepAlive.get() != 0);
-    Assertions.assertEquals(receivedKeepAlive.get(), 0);
-    Assertions.assertEquals(initialCount, SessionManagerTest.getInstance().sessionCount());
+    FakeProtocol fakeProtocol = new FakeProtocol(this) {
+      @Override
+      public long getKeepAliveTaskInterval() {
+        return 500;
+      }
+    };
+    SessionContextBuilder sessionContextBuilder = new SessionContextBuilder(sessionName, new ProtocolClientConnection(fakeProtocol));
+    sessionContextBuilder.setPersistentSession(true)
+        .setResetState(true)
+        .setReceiveMaximum(100)
+        .setSessionExpiry(2);
+    Session session = createSession(sessionContextBuilder, this);
+
+    try {
+      Assertions.assertTrue(SessionManagerTest.getInstance().hasActiveSession(sessionName));
+      WaitForState.waitFor(2, TimeUnit.SECONDS, () -> receivedKeepAlive.get() != 0);
+      Assertions.assertTrue(receivedKeepAlive.get() != 0);
+
+      close(session);
+      Assertions.assertTrue(session.isClosed());
+      Assertions.assertFalse(SessionManagerTest.getInstance().hasActiveSession(sessionName));
+      Assertions.assertNotNull(SessionManagerTest.getInstance().getIdleSubscriptions(sessionName));
+
+      int keepAliveCountAtClose = receivedKeepAlive.get();
+      WaitForState.waitFor(3, TimeUnit.SECONDS,
+          () -> receivedKeepAlive.get() != keepAliveCountAtClose || SessionManagerTest.getInstance().getIdleSubscriptions(sessionName) == null);
+
+      Assertions.assertEquals(keepAliveCountAtClose, receivedKeepAlive.get());
+      Assertions.assertNull(SessionManagerTest.getInstance().getIdleSubscriptions(sessionName));
+    } finally {
+      if (!session.isClosed()) {
+        close(session);
+      }
+      if (SessionManagerTest.getInstance().getIdleSubscriptions(sessionName) != null) {
+        SessionManagerTest.getInstance().closeIdleSession(sessionName);
+      }
+    }
   }
 
   @Test

--- a/src/test/java/io/mapsmessaging/engine/session/SessionManagerTest.java
+++ b/src/test/java/io/mapsmessaging/engine/session/SessionManagerTest.java
@@ -54,6 +54,10 @@ public class SessionManagerTest {
     return manager.getSessions().size();
   }
 
+  public boolean hasActiveSession(String sessionId) {
+    return manager.getSessions().stream().anyMatch(session -> session.getName().equals(sessionId));
+  }
+
   public boolean hasSessions() {
     return manager.hasSessions();
   }


### PR DESCRIPTION
…on context validation

Refactor `sessionKeepAlive` test to utilize `FakeProtocol` for better control over keep-alive intervals. Add comprehensive validations for active and idle session states, received keep-alives, and proper session cleanup. Introduce `hasActiveSession` helper in `SessionManagerTest` to simplify active session checks.