### PR TITLE
fix: pass Throwable in the Throwable slot for endpoint connection logging

### DIFF
--- a/src/main/java/io/mapsmessaging/network/io/connection/state/Disconnected.java
+++ b/src/main/java/io/mapsmessaging/network/io/connection/state/Disconnected.java
@@ -98,7 +98,7 @@ public class Disconnected extends State implements EndPointConnectedCallback {
       endPointConnection.setProtocol(protocolImpl);
       endPointConnection.scheduleState(new Connecting(endPointConnection));
     } catch (IOException ioException) {
-      endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_PROTOCOL_FAILED, url, protocol, ioException);
+      endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_PROTOCOL_FAILED, ioException, url, protocol);
       endPointConnection.scheduleState(new Delayed(endPointConnection), DELAYED_TIME);
     }
   }
@@ -111,7 +111,7 @@ public class Disconnected extends State implements EndPointConnectedCallback {
       List<String> jmxPath = endPointConnection.getJMXPath();
       activeEndPoint = endPointConnection.getEndPointConnectionFactory().connect(url, selectorLoadManager, this, endPointConnection, jmxPath);
     } catch (Exception ioException) {
-      endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_FAILED, url, ioException);
+      endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_FAILED, ioException, url);
       endPointConnection.scheduleState(new Delayed(endPointConnection), DELAYED_TIME);
     }
   }

--- a/src/main/java/io/mapsmessaging/network/io/connection/state/Establishing.java
+++ b/src/main/java/io/mapsmessaging/network/io/connection/state/Establishing.java
@@ -75,7 +75,7 @@ public class Establishing extends State {
         endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_SUBSCRIPTION_ESTABLISHED, direction, property.getLocalNamespace(), remote);
       } catch (IOException ioException) {
         success = false;
-        endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_SUBSCRIPTION_FAILED, direction, property.getLocalNamespace(), remote, ioException);
+        endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_SUBSCRIPTION_FAILED, ioException, direction, property.getLocalNamespace(), remote);
       }
     }
     return success;

--- a/src/main/java/io/mapsmessaging/network/io/connection/state/Hold.java
+++ b/src/main/java/io/mapsmessaging/network/io/connection/state/Hold.java
@@ -69,7 +69,7 @@ public class Hold extends State {
         endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_SUBSCRIPTION_ESTABLISHED, direction, local, remote);
       } catch (IOException ioException) {
         success = false;
-        endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_SUBSCRIPTION_FAILED, direction, local, remote, ioException);
+        endPointConnection.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_SUBSCRIPTION_FAILED, ioException, direction, local, remote);
       }
     }
     return success;

--- a/src/main/java/io/mapsmessaging/network/io/connection/state/StateMonitor.java
+++ b/src/main/java/io/mapsmessaging/network/io/connection/state/StateMonitor.java
@@ -131,7 +131,7 @@ public class StateMonitor implements Runnable {
       try {
         connection.getEndPoint().close();
       } catch (IOException exception) {
-        logger.log(ServerLogMessages.STATE_MONITOR_ENDPOINT_CLOSE_EXCEPTION, connection.getEndPoint(), exception);
+        logger.log(ServerLogMessages.STATE_MONITOR_ENDPOINT_CLOSE_EXCEPTION, exception, connection.getEndPoint());
       }
     }
 

--- a/src/main/java/io/mapsmessaging/network/protocol/Protocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/Protocol.java
@@ -360,7 +360,7 @@ public abstract class Protocol implements SelectorCallback, MessageListener, Tim
           endPoint.getServer().handleCloseEndPoint(endPoint);
         }
       } catch (IOException ioException) {
-        endPoint.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_FAILED, ioException);
+        endPoint.getLogger().log(ServerLogMessages.END_POINT_CONNECTION_FAILED, ioException, endPoint.getName());
         try {
           endPoint.close();
         } catch (IOException e) {


### PR DESCRIPTION
## What

Six call sites in the endpoint connection state machine passed the caught exception as a **trailing vararg** instead of using the `log(LogMessage, Throwable, Object...)` overload.

`simple_logging` validates the vararg count against the number of `{}` placeholders in the template. Where the extra exception argument pushed the count over, the whole call was rejected with:

```
Invalid number of arguments for the log messages, expected 1 received 2
```

and the exception was discarded — leaving only the bare template with no cause and no stack trace.

| Call site | Message | Placeholders | Args passed |
|---|---|---|---|
| `Disconnected.connected` | `END_POINT_CONNECTION_PROTOCOL_FAILED` | 2 | 3 |
| `Disconnected.execute` | `END_POINT_CONNECTION_FAILED` | 1 | 2 |
| `Establishing.processLinkRequests` | `END_POINT_CONNECTION_SUBSCRIPTION_FAILED` | 3 | 4 |
| `Hold.processLinkRequests` | `END_POINT_CONNECTION_SUBSCRIPTION_FAILED` | 3 | 4 |
| `StateMonitor` | `STATE_MONITOR_ENDPOINT_CLOSE_EXCEPTION` | 1 | 2 |
| `Protocol.setConnected` | `END_POINT_CONNECTION_FAILED` | 1 | 1 |

`Protocol.setConnected` is a variant: the arg count happened to match so it did not warn, but the exception was interpolated into the `{}` meant for the endpoint name, and the stack trace was still lost.

## Why it matters

Found while diagnosing a live MQTT 5 inter-server route that would not connect. The outbound connection sat in a 20-second retry loop indefinitely, and the only diagnostic available was:

```
E.21.9.217:1883/_MQTT_5 - Invalid number of arguments for the log messages, expected 1 received 2
E.21.9.217:1883/_MQTT_5 - Exception raised while connecting to remote server tcp://172.21.9.217:1883/
E.21.9.217:1883/_MQTT_5 - Changing state ... from Disconnected to Delayed
```

The actual cause never reached the log. Diagnosis required hand-rolling an MQTT CONNECT probe to bisect network vs. protocol vs. auth, none of which would have been necessary if the exception had been printed.

## Testing

`mvn compile` clean. Change is mechanical argument reordering onto an existing overload — no behavioural change beyond what gets logged.

## Not addressed here

`NetworkConnectionManager` logs three schema-validation warnings on every boot:

```
Configuration for NetworkConnectionManager failed schema validation at required property 'schemaLoadingVersion' not found
Configuration for NetworkConnectionManager failed schema validation at required property 'type' not found
Configuration for NetworkConnectionManager failed schema validation at property 'data' is not defined in the schema and the schema does not allow additional properties
```

The runtime-generated schema comes from `NetworkConnectionManagerConfigDTO`, which declares `endPointServerConfigList`, while `NetworkConnectionManagerConfig` parses `data` from the YAML. `type` is a REQUIRED read-only REST discriminator on `BaseManagerConfigDTO` and `schemaLoadingVersion` sits on `BaseConfigDTO` — neither belongs in an on-disk config file.

It is `LEVEL.WARN` and harmless, but it is permanent boot noise that makes a working config look broken (it sent me down the wrong path for a while). Deciding whether the REST DTO schema should govern YAML validation at all is an architectural call, so I have left it alone rather than guess at a fix that could ripple into the REST contract. Happy to take direction on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected connection and subscription failure logging to display error details and related endpoint information accurately.
  * Improved stale-connection and protocol failure diagnostics by ensuring exceptions and connection context are recorded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->