### PR TITLE
fix(network): trim the configured protocol name in ProtocolFactory

### DIFF
--- a/src/main/java/io/mapsmessaging/network/protocol/ProtocolFactory.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/ProtocolFactory.java
@@ -43,7 +43,10 @@ public class ProtocolFactory implements ServiceManager {
   private final List<ProxyProtocol> proxyProtocols;
 
   public ProtocolFactory(String protocols) {
-    this.protocols = protocols.toLowerCase();
+    // trim() as well as toLowerCase(): a listener config read from a CRLF YAML file yields e.g.
+    // "cot\r", and getBoundedProtocol()'s exact matches() (name.equalsIgnoreCase) then never
+    // matches a single-protocol listener, so it silently falls back to byte detection.
+    this.protocols = protocols.trim().toLowerCase();
     proxyProtocols = List.of(
         new ProxyProtocolV1(),
         new ProxyProtocolV2()


### PR DESCRIPTION

## What

`ProtocolFactory(String protocols)` does `this.protocols = protocols.toLowerCase()`.
`toLowerCase()` does not strip whitespace, so a listener whose `protocol:` value is
read from a CRLF-terminated `NetworkManager.yaml` arrives as `"cot\r"` (or `"cot "`).

`getBoundedProtocol()` then compares with an exact match
(`ProtocolImplFactory.matches` → `name.equalsIgnoreCase(protocols)`), which never
matches a single-protocol listener, so the accept path silently falls back to
byte-level protocol detection. For any protocol whose `Detection` is a no-op /
always-false that means every inbound connection is rejected with
`"No known protocol detected"`.

## Change

```java
-    this.protocols = protocols.toLowerCase();
+    this.protocols = protocols.trim().toLowerCase();
```

One line, plus a comment. `detect()`'s `contains()` checks are unaffected.

## Risk

Minimal — it can only make a previously non-matching config match. Comma-lists
(`"stomp,ws"`) are unchanged (only leading/trailing whitespace is trimmed).


🤖 Generated with [Claude Code](https://claude.com/claude-code)