### PR TITLE
fix(config): make jsonmapper / jsonmutate transformer configs usable from YAML

### DIFF
--- a/src/main/java/io/mapsmessaging/config/transformer/JsonMapperTransformationConfig.java
+++ b/src/main/java/io/mapsmessaging/config/transformer/JsonMapperTransformationConfig.java
@@ -33,8 +33,13 @@ public class JsonMapperTransformationConfig extends JsonMapperTransformationDTO 
 
   public JsonMapperTransformationConfig(ConfigurationProperties props) {
     setType(TransformationType.JSON_MAPPER);
-    ConfigurationProperties jsonMapper = (ConfigurationProperties) props.get("jsonMapper");
-    Object rawOperations = jsonMapper.get("operations");
+    // Accept `operations:` directly on the transformer entry (the shape JsonMutate and the other
+    // transformer configs use); fall back to the legacy `jsonMapper: { operations: [...] }`
+    // nesting if present. The old code assumed the nested form and NPE'd without it.
+    Object rawOperations = props.get("operations");
+    if (rawOperations == null && props.get("jsonMapper") instanceof ConfigurationProperties jsonMapper) {
+      rawOperations = jsonMapper.get("operations");
+    }
     if(rawOperations != null){
       operations = new ArrayList<>();
       if(rawOperations instanceof ConfigurationProperties operationProperties){

--- a/src/main/java/io/mapsmessaging/config/transformer/JsonMutateTransformationConfig.java
+++ b/src/main/java/io/mapsmessaging/config/transformer/JsonMutateTransformationConfig.java
@@ -1,6 +1,9 @@
 package io.mapsmessaging.config.transformer;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
 import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.dto.rest.config.transformer.TransformationType;
 import io.mapsmessaging.dto.rest.config.transformer.impl.JsonMutateTransformationDTO;
@@ -59,13 +62,28 @@ public class JsonMutateTransformationConfig extends JsonMutateTransformationDTO 
       operationDto.setPath(props.getProperty("path"));
       String value = props.getProperty("value");
       if (value != null) {
-        operationDto.setValue(JsonParser.parseString(value));
+        operationDto.setValue(parseJsonOrString(value));
       }
     } else {
       return;
     }
 
     operations.add(operationDto);
+  }
+
+  /**
+   * A jsonmutate SET value from YAML is usually a bare scalar. Parse it as JSON when it is valid
+   * JSON (number, boolean, null, quoted string, object, array); otherwise treat it as a literal
+   * string. The previous strict {@code JsonParser.parseString} threw MalformedJsonException on a
+   * plain word ({@code NEW}) or anything containing a colon (a URL), making string SET values
+   * unusable.
+   */
+  private static JsonElement parseJsonOrString(String raw) {
+    try {
+      return JsonParser.parseString(raw);
+    } catch (JsonSyntaxException e) {
+      return new JsonPrimitive(raw);
+    }
   }
 
 }

--- a/src/test/java/io/mapsmessaging/config/transformer/TransformationConfigFactoryTest.java
+++ b/src/test/java/io/mapsmessaging/config/transformer/TransformationConfigFactoryTest.java
@@ -19,9 +19,12 @@
 
 package io.mapsmessaging.config.transformer;
 
+import com.google.gson.JsonElement;
 import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.dto.rest.config.transformer.TransformationConfigDTO;
 import io.mapsmessaging.dto.rest.config.transformer.TransformationType;
+import io.mapsmessaging.dto.rest.config.transformer.impl.JsonMapperTransformationDTO;
+import io.mapsmessaging.dto.rest.config.transformer.impl.JsonMutateTransformationDTO;
 import io.mapsmessaging.dto.rest.config.transformer.impl.JsonQueryTransformationDTO;
 import io.mapsmessaging.dto.rest.config.transformer.impl.JsonToSchemaTransformationDTO;
 import org.junit.jupiter.api.Test;
@@ -83,5 +86,86 @@ class TransformationConfigFactoryTest {
     assertThrows(IllegalArgumentException.class, () -> TransformationConfigFactory.loadSingle("json-to-xml"));
     assertThrows(IllegalArgumentException.class, () -> TransformationConfigFactory.loadSingle(Map.of("query", "$")));
     assertThrows(IllegalArgumentException.class, () -> TransformationConfigFactory.loadSingle(Map.of("type", "unknown")));
+  }
+
+  @Test
+  void jsonMapper_readsOperationsDirectlyOnTheEntry() {
+    ConfigurationProperties op = new ConfigurationProperties();
+    op.put("from", "body.identifier");
+    op.put("to", "entity.contains[0].value");
+    ConfigurationProperties props = new ConfigurationProperties();
+    props.put("type", "jsonmapper");
+    props.put("operations", List.of(op));
+
+    JsonMapperTransformationDTO result =
+        assertInstanceOf(JsonMapperTransformationDTO.class, TransformationConfigFactory.loadSingle(props));
+    assertEquals(1, result.getOperations().size());
+    assertEquals("body.identifier", result.getOperations().get(0).getFrom());
+    assertEquals("entity.contains[0].value", result.getOperations().get(0).getTo());
+  }
+
+  @Test
+  void jsonMapper_stillAcceptsLegacyNestedForm() {
+    ConfigurationProperties op = new ConfigurationProperties();
+    op.put("to", "entity.name");
+    op.put("defaultValue", "NSIL_CARD");
+    ConfigurationProperties nested = new ConfigurationProperties();
+    nested.put("operations", List.of(op));
+    ConfigurationProperties props = new ConfigurationProperties();
+    props.put("type", "jsonmapper");
+    props.put("jsonMapper", nested);
+
+    JsonMapperTransformationDTO result =
+        assertInstanceOf(JsonMapperTransformationDTO.class, TransformationConfigFactory.loadSingle(props));
+    assertEquals(1, result.getOperations().size());
+    assertEquals("entity.name", result.getOperations().get(0).getTo());
+  }
+
+  @Test
+  void jsonMapper_withNoOperationsDoesNotThrow() {
+    assertInstanceOf(JsonMapperTransformationDTO.class,
+        TransformationConfigFactory.loadSingle(Map.of("type", "jsonmapper")));
+  }
+
+  @Test
+  void jsonMutate_setAcceptsBareStringValues() {
+    ConfigurationProperties setStatus = new ConfigurationProperties();
+    setStatus.put("op", "SET");
+    setStatus.put("path", "entity.contains[0].value");
+    setStatus.put("value", "NEW");
+    ConfigurationProperties setNs = new ConfigurationProperties();
+    setNs.put("op", "SET");
+    setNs.put("path", "entity.@xmlns:xsi");
+    setNs.put("value", "http://www.w3.org/2001/XMLSchema-instance");
+    ConfigurationProperties props = new ConfigurationProperties();
+    props.put("type", "jsonmutate");
+    props.put("operations", List.of(setStatus, setNs));
+
+    JsonMutateTransformationDTO result =
+        assertInstanceOf(JsonMutateTransformationDTO.class, TransformationConfigFactory.loadSingle(props));
+    assertEquals(2, result.getOperations().size());
+    assertEquals("NEW", ((JsonElement) result.getOperations().get(0).getValue()).getAsString());
+    assertEquals("http://www.w3.org/2001/XMLSchema-instance",
+        ((JsonElement) result.getOperations().get(1).getValue()).getAsString());
+  }
+
+  @Test
+  void jsonMutate_setStillParsesJsonScalars() {
+    ConfigurationProperties setNum = new ConfigurationProperties();
+    setNum.put("op", "SET");
+    setNum.put("path", "count");
+    setNum.put("value", "42");
+    ConfigurationProperties setBool = new ConfigurationProperties();
+    setBool.put("op", "SET");
+    setBool.put("path", "flag");
+    setBool.put("value", "true");
+    ConfigurationProperties props = new ConfigurationProperties();
+    props.put("type", "jsonmutate");
+    props.put("operations", List.of(setNum, setBool));
+
+    JsonMutateTransformationDTO result =
+        assertInstanceOf(JsonMutateTransformationDTO.class, TransformationConfigFactory.loadSingle(props));
+    assertEquals(42, ((JsonElement) result.getOperations().get(0).getValue()).getAsInt());
+    assertTrue(((JsonElement) result.getOperations().get(1).getValue()).getAsBoolean());
   }
 }


### PR DESCRIPTION

Two independent breakages when a `jsonmapper` or `jsonmutate` transformation is
declared in an `AggregatorManager` (or link) `transformer:` chain from YAML.

## 1. JsonMapperTransformationConfig NPEs without an undocumented wrapper

```java
ConfigurationProperties jsonMapper = (ConfigurationProperties) props.get("jsonMapper");
Object rawOperations = jsonMapper.get("operations");   // NPE when there is no jsonMapper: sub-map
```

`JsonMutateTransformationConfig`, `GeoHashResolverTransformationConfig`, etc. all
read their fields directly off the entry. `jsonmapper` alone required a
`jsonMapper: { operations: [...] }` nesting, and dereferenced it with no null
check, so the natural

```yaml
- type: jsonmapper
  operations:
    - { from: a.b, to: x.y }
```

threw in the constructor.

**Fix:** read `operations:` directly off the entry; fall back to
`jsonMapper.operations` only for the legacy nested form; null-guard.

## 2. JsonMutateTransformationConfig rejects string SET values

```java
operationDto.setValue(JsonParser.parseString(value));   // strict
```

A `SET` op's `value:` from YAML is normally a bare scalar. `JsonParser.parseString`
is strict, so `value: NEW` or `value: http://example/...` (the `:` breaks it)
throws `MalformedJsonException` and string SET values are impossible.

**Fix:** parse as JSON when the value *is* valid JSON (number / boolean / null /
quoted string / object / array); treat it as a literal string otherwise.

## Tests

5 new cases in `TransformationConfigFactoryTest` (10/10 pass):
direct `operations:` on jsonmapper, the legacy nested form still works, jsonmapper
with no operations doesn't throw, jsonmutate SET accepts bare strings / a URL,
jsonmutate SET still parses numeric & boolean scalars.


🤖 Generated with [Claude Code](https://claude.com/claude-code)