### PR TITLE
feat: CoT XML passthrough listener + optional TAK-server mutual TLS

### DIFF
--- a/src/main/java/io/mapsmessaging/config/network/EndPointConfigFactory.java
+++ b/src/main/java/io/mapsmessaging/config/network/EndPointConfigFactory.java
@@ -199,6 +199,7 @@ public class EndPointConfigFactory {
       case "nmea-0183" -> new NmeaConfig(config);
       case "lora" -> new LoRaProtocolConfig(config);
       case "echo" -> new EchoProtocolConfig(config);
+      case "cot" -> new CotProtocolConfig(config);
       case "stogi" -> new StoGiConfig(config);
       case "satellite" -> new SatelliteConfig(config);
       case "mavlink" -> new MavlinkConfig(config);

--- a/src/main/java/io/mapsmessaging/config/protocol/impl/CotProtocolConfig.java
+++ b/src/main/java/io/mapsmessaging/config/protocol/impl/CotProtocolConfig.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.config.protocol.impl;
+
+import io.mapsmessaging.config.Config;
+import io.mapsmessaging.config.network.KeyStoreConfig;
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.dto.rest.config.BaseConfigDTO;
+import io.mapsmessaging.dto.rest.config.protocol.impl.CotProtocolConfigDTO;
+
+public class CotProtocolConfig extends CotProtocolConfigDTO implements Config {
+
+  public CotProtocolConfig(ConfigurationProperties config) {
+    setType("cot");
+    ProtocolConfigFactory.unpack(config, this);
+    this.takHostname = config.getProperty("takHostname", takHostname);
+    this.takPort = config.getIntProperty("takPort", takPort);
+    this.takTlsEnabled = config.getBooleanProperty("takTlsEnabled", takTlsEnabled);
+    this.takTlsContext = config.getProperty("takTlsContext", takTlsContext);
+
+    ConfigurationProperties keyStoreProps = (ConfigurationProperties) config.get("takKeyStore");
+    if (keyStoreProps != null) {
+      this.takKeyStore = new KeyStoreConfig(keyStoreProps);
+    }
+    ConfigurationProperties trustStoreProps = (ConfigurationProperties) config.get("takTrustStore");
+    if (trustStoreProps != null) {
+      this.takTrustStore = new KeyStoreConfig(trustStoreProps);
+    }
+  }
+
+  @Override
+  public boolean update(BaseConfigDTO config) {
+    boolean hasChanged = false;
+    if (config instanceof CotProtocolConfigDTO newConfig) {
+      if (!this.takHostname.equals(newConfig.getTakHostname())) {
+        this.takHostname = newConfig.getTakHostname();
+        hasChanged = true;
+      }
+      if (this.takPort != newConfig.getTakPort()) {
+        this.takPort = newConfig.getTakPort();
+        hasChanged = true;
+      }
+      if (this.takTlsEnabled != newConfig.isTakTlsEnabled()) {
+        this.takTlsEnabled = newConfig.isTakTlsEnabled();
+        hasChanged = true;
+      }
+      if (!this.takTlsContext.equals(newConfig.getTakTlsContext())) {
+        this.takTlsContext = newConfig.getTakTlsContext();
+        hasChanged = true;
+      }
+      if (this.takKeyStore != null && ((Config) this.takKeyStore).update(newConfig.getTakKeyStore())) {
+        hasChanged = true;
+      }
+      if (this.takTrustStore != null && ((Config) this.takTrustStore).update(newConfig.getTakTrustStore())) {
+        hasChanged = true;
+      }
+      if (ProtocolConfigFactory.update(this, newConfig)) {
+        hasChanged = true;
+      }
+    }
+    return hasChanged;
+  }
+
+  @Override
+  public ConfigurationProperties toConfigurationProperties() {
+    ConfigurationProperties properties = new ConfigurationProperties();
+    ProtocolConfigFactory.pack(properties, this);
+    properties.put("takHostname", this.takHostname);
+    properties.put("takPort", this.takPort);
+    properties.put("takTlsEnabled", this.takTlsEnabled);
+    properties.put("takTlsContext", this.takTlsContext);
+    if (this.takKeyStore != null) {
+      properties.put("takKeyStore", ((Config) this.takKeyStore).toConfigurationProperties());
+    }
+    if (this.takTrustStore != null) {
+      properties.put("takTrustStore", ((Config) this.takTrustStore).toConfigurationProperties());
+    }
+    return properties;
+  }
+}

--- a/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/CotProtocolConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/CotProtocolConfigDTO.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.dto.rest.config.protocol.impl;
+
+import io.mapsmessaging.dto.rest.config.network.KeyStoreConfigDTO;
+import io.mapsmessaging.dto.rest.config.protocol.ProtocolConfigDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Schema(description = "Raw CoT XML passthrough ingest protocol Configuration DTO")
+public class CotProtocolConfigDTO extends ProtocolConfigDTO {
+
+  public CotProtocolConfigDTO() {
+    super("cot");
+  }
+
+  @Schema(description = "Hostname of the real TAK server each received CoT event is forwarded to", example = "tak.example.org")
+  protected String takHostname = "";
+
+  @Schema(description = "Port of the real TAK server each received CoT event is forwarded to", example = "8088")
+  protected int takPort = 8088;
+
+  @Schema(description = "If true, the connection to the TAK server uses TLS instead of plain TCP", example = "false")
+  protected boolean takTlsEnabled = false;
+
+  @Schema(description = "TLS protocol used for the TAK server connection when takTlsEnabled is true", example = "TLSv1.2")
+  protected String takTlsContext = "TLSv1.2";
+
+  @Schema(description = "Key store presenting this broker's client certificate to the TAK server (mutual TLS). Required when takTlsEnabled is true.")
+  protected KeyStoreConfigDTO takKeyStore;
+
+  @Schema(description = "Trust store used to validate the TAK server's certificate. Required when takTlsEnabled is true.")
+  protected KeyStoreConfigDTO takTrustStore;
+}

--- a/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/TakProtocolDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/TakProtocolDTO.java
@@ -20,6 +20,7 @@
 
 package io.mapsmessaging.dto.rest.config.protocol.impl;
 
+import io.mapsmessaging.dto.rest.config.network.KeyStoreConfigDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -59,5 +60,27 @@ public class TakProtocolDTO {
       nullable = true
   )
   private String topic = null;
+
+  @Schema(
+      description = "If true, connect to the TAK server over TLS instead of plain TCP.",
+      example = "false",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      defaultValue = "false"
+  )
+  private boolean tlsEnabled = false;
+
+  @Schema(
+      description = "TLS protocol used for the connection when tlsEnabled is true.",
+      example = "TLSv1.2",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      defaultValue = "TLSv1.2"
+  )
+  private String tlsContext = "TLSv1.2";
+
+  @Schema(description = "Key store presenting this broker's client certificate to the TAK server (mutual TLS). Required when tlsEnabled is true.")
+  private KeyStoreConfigDTO keyStore;
+
+  @Schema(description = "Trust store used to validate the TAK server's certificate. Required when tlsEnabled is true.")
+  private KeyStoreConfigDTO trustStore;
 
 }

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/cot/CotProtocol.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/cot/CotProtocol.java
@@ -1,0 +1,370 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.network.protocol.impl.cot;
+
+import io.mapsmessaging.api.MessageBuilder;
+import io.mapsmessaging.api.MessageEvent;
+import io.mapsmessaging.api.Session;
+import io.mapsmessaging.api.SessionContextBuilder;
+import io.mapsmessaging.api.SessionManager;
+import io.mapsmessaging.api.features.DestinationType;
+import io.mapsmessaging.api.features.QualityOfService;
+import io.mapsmessaging.api.message.Message;
+import io.mapsmessaging.config.Config;
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.dto.rest.config.protocol.impl.CotProtocolConfigDTO;
+import io.mapsmessaging.dto.rest.protocol.ProtocolInformationDTO;
+import io.mapsmessaging.network.ProtocolClientConnection;
+import io.mapsmessaging.network.io.EndPoint;
+import io.mapsmessaging.network.io.Packet;
+import io.mapsmessaging.network.io.Selectable;
+import io.mapsmessaging.network.io.impl.Selector;
+import io.mapsmessaging.network.protocol.Protocol;
+import io.mapsmessaging.security.ssl.SslHelper;
+import io.mapsmessaging.state.drone.tak.TakSocketConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SelectionKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Accepts a raw, unframed stream of Cursor-on-Target (CoT) XML &lt;event&gt; documents (the wire
+ * format used by TAK clients/servers) and republishes each complete document, byte for byte and
+ * with no parsing, onto a fixed topic, and - when takHostname is configured - forwards it directly
+ * over its own TakSocketConnection to a real TAK server, the same mechanism TwinManager's own
+ * drone-state pipeline uses. There is no application level login on this connection - the session
+ * authenticates as the built in anonymous identity, the same identity the existing anonymous Stomp
+ * interface uses. Transport security is provided by binding this protocol to an ssl:// listener in
+ * NetworkManager.yaml.
+ *
+ * <p>Discovered via the standard ProtocolImplFactory ServiceLoader registration. Logging uses
+ * SLF4J for now (this protocol carries no {@code ServerLogMessages} constants of its own);
+ * {@link #mapsLogger} exists because {@link SslHelper#createContext} takes a MAPS logger.
+ */
+public class CotProtocol extends Protocol implements Selectable {
+
+  private static final String DESTINATION_NAME = "/tak/cot/inbound";
+  private static final int MAX_BUFFER_SIZE = 1_048_576; // 1MB safety cap against a malformed/never-terminated stream
+
+  private static final byte[] EVENT_START = "<event".getBytes(StandardCharsets.US_ASCII);
+  private static final byte[] EVENT_END = "</event>".getBytes(StandardCharsets.US_ASCII);
+  private static final byte[] XML_DECL_START = "<?xml".getBytes(StandardCharsets.US_ASCII);
+  private static final byte[] XML_DECL_END = "?>".getBytes(StandardCharsets.US_ASCII);
+
+  private static final ExecutorService READER_POOL = Executors.newCachedThreadPool(runnable -> {
+    Thread thread = new Thread(runnable, "cot-protocol-reader");
+    thread.setDaemon(true);
+    return thread;
+  });
+
+  private final Logger logger = LoggerFactory.getLogger(CotProtocol.class);
+  private final io.mapsmessaging.logging.Logger mapsLogger =
+      io.mapsmessaging.logging.LoggerFactory.getLogger(CotProtocol.class);
+  private final Packet packet;
+  private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+  private final String sessionId;
+  private final TakSocketConnection takSocketConnection;
+
+  private Session session;
+  private boolean closed;
+
+  public CotProtocol(EndPoint endPoint, Packet initialPacket, CotProtocolConfigDTO config) throws IOException {
+    super(endPoint, config != null ? config : new CotProtocolConfigDTO());
+    this.packet = initialPacket;
+    this.sessionId = "cot-" + UUID.randomUUID();
+    this.takSocketConnection = buildTakSocketConnection(config);
+    createSession();
+    logger.debug("CoT passthrough connection created on {}", endPoint.getConfig().getUrl());
+    if (initialPacket.available() > 0) {
+      appendAndProcess(initialPacket);
+    }
+    endPoint.register(SelectionKey.OP_READ, this);
+  }
+
+  private TakSocketConnection buildTakSocketConnection(CotProtocolConfigDTO config) throws IOException {
+    if (config == null || config.getTakHostname() == null || config.getTakHostname().isBlank()) {
+      return null;
+    }
+    if (!config.isTakTlsEnabled()) {
+      return new TakSocketConnection(config.getTakHostname(), config.getTakPort());
+    }
+    ConfigurationProperties sslProps = new ConfigurationProperties();
+    sslProps.put("keyStore", ((Config) config.getTakKeyStore()).toConfigurationProperties());
+    sslProps.put("trustStore", ((Config) config.getTakTrustStore()).toConfigurationProperties());
+    SSLContext sslContext = SslHelper.createContext(config.getTakTlsContext(), sslProps, mapsLogger);
+    return new TakSocketConnection(config.getTakHostname(), config.getTakPort(), sslContext.getSocketFactory());
+  }
+
+  private void createSession() throws IOException {
+    try {
+      SessionContextBuilder scb = new SessionContextBuilder(sessionId, new ProtocolClientConnection(this));
+      scb.setUsername("anonymous")
+          .setPassword("".toCharArray())
+          .setPersistentSession(false)
+          .setSessionExpiry(0)
+          .setReceiveMaximum(1);
+      session = SessionManager.getInstance().create(scb.build(), this);
+    } catch (LoginException e) {
+      logger.error("CoT passthrough session creation failed", e);
+      throw new IOException("Unable to create CoT passthrough session", e);
+    }
+  }
+
+  @Override
+  public void selected(Selectable selectable, Selector selector, int selection) {
+    try {
+      endPoint.deregister(SelectionKey.OP_READ);
+    } catch (ClosedChannelException e) {
+      logger.warn("Exception reading from CoT passthrough connection", e);
+      return;
+    }
+    READER_POOL.execute(new ReadTask());
+  }
+
+  private final class ReadTask implements Runnable {
+    @Override
+    public void run() {
+      Thread.currentThread().setName("CoT Protocol Reader::" + Thread.currentThread().getName());
+      try {
+        int read;
+        boolean first = true;
+        do {
+          packet.clear();
+          read = endPoint.readPacket(packet);
+          if (read > 0) {
+            EndPoint.totalReceived.increment();
+            packet.flip();
+            appendAndProcess(packet);
+          } else if (first) {
+            closeQuietly();
+            return;
+          }
+          first = false;
+        } while (read > 0);
+        endPoint.register(SelectionKey.OP_READ, CotProtocol.this);
+      } catch (Exception e) {
+        logger.warn("Exception reading from CoT passthrough connection", e);
+        closeQuietly();
+      }
+    }
+  }
+
+  private void appendAndProcess(Packet packet) throws IOException {
+    byte[] chunk = new byte[packet.available()];
+    packet.get(chunk);
+    buffer.write(chunk);
+    processBuffer();
+  }
+
+  private void processBuffer() {
+    byte[] data = buffer.toByteArray();
+    int scanFrom = 0;
+    int consumedUpTo = 0;
+    while (true) {
+      int eventStart = indexOf(data, EVENT_START, scanFrom);
+      if (eventStart < 0) {
+        break;
+      }
+      int endTagIdx = indexOf(data, EVENT_END, eventStart + EVENT_START.length);
+      if (endTagIdx < 0) {
+        break; // Incomplete document, wait for more data
+      }
+      int docEnd = endTagIdx + EVENT_END.length;
+      int docStart = findPrecedingXmlDeclaration(data, eventStart, consumedUpTo);
+      byte[] document = Arrays.copyOfRange(data, docStart, docEnd);
+      publish(document);
+      consumedUpTo = docEnd;
+      scanFrom = docEnd;
+    }
+
+    buffer.reset();
+    if (consumedUpTo < data.length) {
+      buffer.write(data, consumedUpTo, data.length - consumedUpTo);
+    }
+    if (buffer.size() > MAX_BUFFER_SIZE) {
+      logger.warn("CoT passthrough buffer exceeded {} bytes without a complete event, discarding buffered data", MAX_BUFFER_SIZE);
+      buffer.reset();
+    }
+  }
+
+  private int findPrecedingXmlDeclaration(byte[] data, int eventStart, int lowerBound) {
+    int declStart = lastIndexOf(data, XML_DECL_START, lowerBound, eventStart);
+    if (declStart < 0) {
+      return eventStart;
+    }
+    int declEnd = indexOf(data, XML_DECL_END, declStart);
+    if (declEnd < 0 || declEnd + XML_DECL_END.length > eventStart) {
+      return eventStart;
+    }
+    int afterDecl = declEnd + XML_DECL_END.length;
+    if (!isWhitespaceOnly(data, afterDecl, eventStart)) {
+      return eventStart;
+    }
+    return declStart;
+  }
+
+  private void publish(byte[] xml) {
+    Message message = new MessageBuilder()
+        .setOpaqueData(xml)
+        .setContentType("text/xml")
+        .setQoS(QualityOfService.AT_MOST_ONCE)
+        .setRetain(false)
+        .build();
+
+    session.findDestination(DESTINATION_NAME, DestinationType.TOPIC).whenComplete((destination, throwable) -> {
+      if (throwable != null) {
+        logger.error("Failed to publish CoT event to {}", DESTINATION_NAME, throwable);
+        return;
+      }
+      if (destination != null) {
+        try {
+          destination.storeMessage(message);
+        } catch (IOException e) {
+          logger.error("Failed to publish CoT event to {}", DESTINATION_NAME, e);
+        }
+      }
+    });
+
+    if (takSocketConnection != null) {
+      takSocketConnection.accept(new String(xml, StandardCharsets.UTF_8));
+    }
+  }
+
+  private static int indexOf(byte[] data, byte[] pattern, int from) {
+    int max = data.length - pattern.length;
+    outer:
+    for (int i = Math.max(from, 0); i <= max; i++) {
+      for (int j = 0; j < pattern.length; j++) {
+        if (data[i + j] != pattern[j]) {
+          continue outer;
+        }
+      }
+      return i;
+    }
+    return -1;
+  }
+
+  private static int lastIndexOf(byte[] data, byte[] pattern, int from, int to) {
+    int max = Math.min(to, data.length) - pattern.length;
+    outer:
+    for (int i = max; i >= from; i--) {
+      for (int j = 0; j < pattern.length; j++) {
+        if (data[i + j] != pattern[j]) {
+          continue outer;
+        }
+      }
+      return i;
+    }
+    return -1;
+  }
+
+  private static boolean isWhitespaceOnly(byte[] data, int from, int to) {
+    for (int i = from; i < to; i++) {
+      if (!Character.isWhitespace(data[i] & 0xff)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void closeQuietly() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (takSocketConnection != null) {
+      takSocketConnection.close();
+    }
+    try {
+      if (session != null) {
+        SessionManager.getInstance().close(session, false);
+      }
+    } catch (IOException e) {
+      logger.warn("Exception reading from CoT passthrough connection", e);
+    }
+    try {
+      super.close();
+    } catch (IOException e) {
+      logger.warn("Exception reading from CoT passthrough connection", e);
+    }
+    logger.debug("CoT passthrough connection closed");
+  }
+
+  @Override
+  public void close() throws IOException {
+    closeQuietly();
+  }
+
+  @Override
+  public Subject getSubject() {
+    return session != null ? session.getSecurityContext().getSubject() : null;
+  }
+
+  @Override
+  public void sendMessage(MessageEvent messageEvent) {
+    // This is an inbound only listener, nothing is ever subscribed through it
+    if (messageEvent.getCompletionTask() != null) {
+      messageEvent.getCompletionTask().run();
+    }
+  }
+
+  @Override
+  public void sendKeepAlive() {
+    // No keep alive required for this passthrough listener
+  }
+
+  @Override
+  public boolean processPacket(Packet packet) throws IOException {
+    return false; // Reading is handled directly via the selector callback + ReadTask
+  }
+
+  @Override
+  public String getName() {
+    return "CoT";
+  }
+
+  @Override
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  @Override
+  public String getVersion() {
+    return "1.0";
+  }
+
+  @Override
+  public ProtocolInformationDTO getInformation() {
+    ProtocolInformationDTO dto = new ProtocolInformationDTO();
+    updateInformation(dto);
+    return dto;
+  }
+}

--- a/src/main/java/io/mapsmessaging/network/protocol/impl/cot/CotProtocolFactory.java
+++ b/src/main/java/io/mapsmessaging/network/protocol/impl/cot/CotProtocolFactory.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.network.protocol.impl.cot;
+
+import io.mapsmessaging.dto.rest.config.protocol.impl.CotProtocolConfigDTO;
+import io.mapsmessaging.network.io.EndPoint;
+import io.mapsmessaging.network.io.Packet;
+import io.mapsmessaging.network.protocol.Protocol;
+import io.mapsmessaging.network.protocol.ProtocolImplFactory;
+import io.mapsmessaging.network.protocol.detection.MultiByteArrayDetection;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Accepts a raw, unframed stream of Cursor-on-Target (CoT) XML &lt;event&gt; documents and
+ * republishes each one, byte for byte, onto a fixed topic. This is an inbound-only listener,
+ * it does not initiate outbound connections.
+ *
+ * <p>Registered via {@code META-INF/services/io.mapsmessaging.network.protocol.ProtocolImplFactory};
+ * the {@code cot} listener config is parsed by {@link io.mapsmessaging.config.protocol.impl.CotProtocolConfig}
+ * ({@code EndPointConfigFactory} {@code case "cot"}).
+ */
+public class CotProtocolFactory extends ProtocolImplFactory {
+
+  // Match the start of a CoT stream so the plain-tcp:// accept path (ProtocolFactory.detect)
+  // recognises this protocol. NoOpDetection returns false and only works behind an ssl://
+  // listener (where the TLS handshake stands in for byte detection); a raw tcp:// listener
+  // needs a real Detection or every connection is rejected as "No known protocol detected".
+  private static final byte[][] COT_STREAM_STARTS = {
+    "<?xml".getBytes(StandardCharsets.US_ASCII),
+    "<event".getBytes(StandardCharsets.US_ASCII),
+  };
+
+  public CotProtocolFactory() {
+    super("cot", "Raw CoT XML passthrough ingest", new MultiByteArrayDetection(COT_STREAM_STARTS, 0));
+  }
+
+  @Override
+  public Protocol connect(EndPoint endPoint, String sessionId, String username, String password, Map<String, String> topicMap) throws IOException {
+    return null; // Inbound listener only, does not support initiating connections
+  }
+
+  @Override
+  public void create(EndPoint endPoint, Packet packet) throws IOException {
+    CotProtocolConfigDTO config = (CotProtocolConfigDTO) endPoint.getConfig().getProtocolConfig("cot");
+    new CotProtocol(endPoint, packet, config);
+  }
+
+  @Override
+  public String getTransportType() {
+    return "tcp";
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/config/TwinManagerConfig.java
+++ b/src/main/java/io/mapsmessaging/state/config/TwinManagerConfig.java
@@ -21,6 +21,7 @@ package io.mapsmessaging.state.config;
 
 import io.mapsmessaging.config.Config;
 import io.mapsmessaging.config.ConfigManager;
+import io.mapsmessaging.config.network.KeyStoreConfig;
 import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.dto.rest.config.BaseConfigDTO;
 import io.mapsmessaging.dto.rest.config.protocol.impl.MavlinkKnownSourceDTO;
@@ -55,6 +56,16 @@ public class TwinManagerConfig extends TwinManagerConfigDTO implements Config, C
       takProtocolDTO.setPort(takProps.getIntProperty("port", takProtocolDTO.getPort()));
       takProtocolDTO.setSharedConnection(takProps.getBooleanProperty("sharedConnection", takProtocolDTO.isSharedConnection()));
       takProtocolDTO.setTopic(takProps.getProperty("topic", null));
+      takProtocolDTO.setTlsEnabled(takProps.getBooleanProperty("tlsEnabled", takProtocolDTO.isTlsEnabled()));
+      takProtocolDTO.setTlsContext(takProps.getProperty("tlsContext", takProtocolDTO.getTlsContext()));
+      ConfigurationProperties keyStoreProps = (ConfigurationProperties) takProps.get("keyStore");
+      if (keyStoreProps != null) {
+        takProtocolDTO.setKeyStore(new KeyStoreConfig(keyStoreProps));
+      }
+      ConfigurationProperties trustStoreProps = (ConfigurationProperties) takProps.get("trustStore");
+      if (trustStoreProps != null) {
+        takProtocolDTO.setTrustStore(new KeyStoreConfig(trustStoreProps));
+      }
       this.tak = takProtocolDTO;
     }
 

--- a/src/main/java/io/mapsmessaging/state/drone/tak/TakSocketConnection.java
+++ b/src/main/java/io/mapsmessaging/state/drone/tak/TakSocketConnection.java
@@ -21,6 +21,8 @@ package io.mapsmessaging.state.drone.tak;
 
 import lombok.Getter;
 
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -48,6 +50,7 @@ public class TakSocketConnection implements Closeable {
 
   private final LinkedBlockingDeque<String> queue;
   private final Thread writerThread;
+  private final SSLSocketFactory sslSocketFactory;
 
   private volatile boolean running;
 
@@ -55,7 +58,11 @@ public class TakSocketConnection implements Closeable {
   private OutputStream socketOutputStream;
 
   public TakSocketConnection(String host, int port) {
-    this(host, port, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_SOCKET_TIMEOUT_MS, true, DEFAULT_MAX_QUEUE_SIZE);
+    this(host, port, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_SOCKET_TIMEOUT_MS, true, DEFAULT_MAX_QUEUE_SIZE, null);
+  }
+
+  public TakSocketConnection(String host, int port, SSLSocketFactory sslSocketFactory) {
+    this(host, port, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_SOCKET_TIMEOUT_MS, true, DEFAULT_MAX_QUEUE_SIZE, sslSocketFactory);
   }
 
   public TakSocketConnection(String host,
@@ -64,6 +71,16 @@ public class TakSocketConnection implements Closeable {
                              int socketTimeoutMs,
                              boolean appendNewLine,
                              int maxQueueSize) {
+    this(host, port, connectTimeoutMs, socketTimeoutMs, appendNewLine, maxQueueSize, null);
+  }
+
+  public TakSocketConnection(String host,
+                             int port,
+                             int connectTimeoutMs,
+                             int socketTimeoutMs,
+                             boolean appendNewLine,
+                             int maxQueueSize,
+                             SSLSocketFactory sslSocketFactory) {
     this.host = Objects.requireNonNull(host, "host cannot be null");
     this.port = port;
     this.connectTimeoutMs = connectTimeoutMs;
@@ -74,6 +91,7 @@ public class TakSocketConnection implements Closeable {
     this.running = true;
     this.socket = null;
     this.socketOutputStream = null;
+    this.sslSocketFactory = sslSocketFactory;
 
     this.writerThread = new Thread(this::writerLoop, "tak-socket-writer-" + host + "-" + port);
     this.writerThread.setDaemon(true);
@@ -156,8 +174,16 @@ public class TakSocketConnection implements Closeable {
     closeQuietly();
 
     try {
-      Socket newSocket = new Socket();
-      newSocket.connect(new InetSocketAddress(host, port), connectTimeoutMs);
+      Socket newSocket;
+      if (sslSocketFactory != null) {
+        SSLSocket sslSocket = (SSLSocket) sslSocketFactory.createSocket();
+        sslSocket.connect(new InetSocketAddress(host, port), connectTimeoutMs);
+        sslSocket.startHandshake();
+        newSocket = sslSocket;
+      } else {
+        newSocket = new Socket();
+        newSocket.connect(new InetSocketAddress(host, port), connectTimeoutMs);
+      }
       newSocket.setSoTimeout(socketTimeoutMs);
       newSocket.setKeepAlive(true);
       newSocket.setTcpNoDelay(true);

--- a/src/main/java/io/mapsmessaging/state/drone/tak/TakTwinObserver.java
+++ b/src/main/java/io/mapsmessaging/state/drone/tak/TakTwinObserver.java
@@ -19,6 +19,12 @@
 
 package io.mapsmessaging.state.drone.tak;
 
+import io.mapsmessaging.config.Config;
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.dto.rest.config.protocol.impl.TakProtocolDTO;
+import io.mapsmessaging.logging.Logger;
+import io.mapsmessaging.logging.LoggerFactory;
+import io.mapsmessaging.security.ssl.SslHelper;
 import io.mapsmessaging.state.config.TwinManagerConfig;
 import io.mapsmessaging.state.config.TwinManagerConfigDTO;
 import io.mapsmessaging.state.drone.core.EntityTwin;
@@ -29,8 +35,11 @@ import io.mapsmessaging.state.drone.core.TwinRelationship;
 import io.mapsmessaging.state.drone.core.TwinUpdateContext;
 import io.mapsmessaging.state.drone.model.BatteryState;
 import io.mapsmessaging.state.drone.tak.model.TakEvent;
+import io.mapsmessaging.state.logging.StateLogMessages;
 import io.mapsmessaging.utilities.configuration.ConfigurationManager;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
@@ -44,10 +53,13 @@ public class TakTwinObserver implements TwinObserver {
   private static final long PUBLISH_INTERVAL_MS = 1000L;
   private static final long STATS_PUBLISH_INTERVAL_MS = 30_000L;
 
+  private final Logger logger = LoggerFactory.getLogger(TakTwinObserver.class);
+
   private final Map<String, TakTwinContext> takContexts;
   private final Map<String, Long> lastStatsPublishTimes;
   private final String takHost;
   private final int takPort;
+  private final SSLSocketFactory sslSocketFactory;
   private final TwinManager twinManager;
   private final TakEventMapper takEventMapper;
   private final TakXmlSerialiser takXmlSerialiser;
@@ -67,12 +79,13 @@ public class TakTwinObserver implements TwinObserver {
     if (config != null && config.getTak() != null) {
       this.takHost = config.getTak().getHostname();
       this.takPort = config.getTak().getPort();
+      this.sslSocketFactory = buildSslSocketFactory(config.getTak());
 
       if (config.getTak().isSharedConnection()
           && takHost != null
           && !takHost.isBlank()
           && takPort > 0) {
-        globalSocketConnection = new TakSocketConnection(takHost, takPort);
+        globalSocketConnection = new TakSocketConnection(takHost, takPort, sslSocketFactory);
       } else {
         globalSocketConnection = null;
       }
@@ -94,8 +107,25 @@ public class TakTwinObserver implements TwinObserver {
     } else {
       this.takHost = null;
       this.takPort = 0;
+      this.sslSocketFactory = null;
       this.globalSocketConnection = null;
       this.eventPublisher = null;
+    }
+  }
+
+  private SSLSocketFactory buildSslSocketFactory(TakProtocolDTO tak) {
+    if (!tak.isTlsEnabled() || tak.getKeyStore() == null || tak.getTrustStore() == null) {
+      return null;
+    }
+    try {
+      ConfigurationProperties sslProps = new ConfigurationProperties();
+      sslProps.put("keyStore", ((Config) tak.getKeyStore()).toConfigurationProperties());
+      sslProps.put("trustStore", ((Config) tak.getTrustStore()).toConfigurationProperties());
+      SSLContext sslContext = SslHelper.createContext(tak.getTlsContext(), sslProps, logger);
+      return sslContext.getSocketFactory();
+    } catch (IOException e) {
+      logger.log(StateLogMessages.STATE_MANAGER_TAK_TLS_CONTEXT_FAILED, e);
+      return null;
     }
   }
 
@@ -230,7 +260,7 @@ public class TakTwinObserver implements TwinObserver {
       if (twinContext.getSocketConnection() == null) {
         twinContext.setSocketConnection(
             Objects.requireNonNullElseGet(
-                globalSocketConnection, () -> new TakSocketConnection(takHost, takPort)));
+                globalSocketConnection, () -> new TakSocketConnection(takHost, takPort, sslSocketFactory)));
       }
 
       twinContext.getSocketConnection().accept(xml);

--- a/src/main/java/io/mapsmessaging/state/logging/StateLogMessages.java
+++ b/src/main/java/io/mapsmessaging/state/logging/StateLogMessages.java
@@ -134,7 +134,9 @@ public enum StateLogMessages implements LogMessage {
   MAVLINK_EVENT_LIST_SENDER_NO_ACK_ADVANCING(LEVEL.INFO, SERVER_CATEGORY.PROTOCOL, "MAVLink message for sender '{}', index {}, does not require acknowledgement, advancing"),
 
   MAVLINK_TWIN_MANAGER_START_FAILED(LEVEL.ERROR, SERVER_CATEGORY.PROTOCOL, "Failed to start MAVLink twin manager subscriber: {}"),
-  MAVLINK_TWIN_MANAGER_STOP_FAILED(LEVEL.ERROR, SERVER_CATEGORY.PROTOCOL, "Failed to stop MAVLink twin manager subscriber: {}");
+  MAVLINK_TWIN_MANAGER_STOP_FAILED(LEVEL.ERROR, SERVER_CATEGORY.PROTOCOL, "Failed to stop MAVLink twin manager subscriber: {}"),
+
+  STATE_MANAGER_TAK_TLS_CONTEXT_FAILED(LEVEL.ERROR, SERVER_CATEGORY.STATE, "Failed to build TLS context for TAK server connection, falling back to plain TCP");
   //-------------------------------------------------------------------------------------------------------------
 
   private final @Getter String message;

--- a/src/main/resources/META-INF/services/io.mapsmessaging.network.protocol.ProtocolImplFactory
+++ b/src/main/resources/META-INF/services/io.mapsmessaging.network.protocol.ProtocolImplFactory
@@ -41,6 +41,11 @@ io.mapsmessaging.network.protocol.impl.nats.NatsProtocolFactory
 io.mapsmessaging.network.protocol.impl.nmea.NMEAProtocolFactory
 
 #
+# Cursor-on-Target (TAK) raw XML passthrough ingest
+#
+io.mapsmessaging.network.protocol.impl.cot.CotProtocolFactory
+
+#
 # OrbComm based protocols to support Satellite communications
 #
 io.mapsmessaging.network.protocol.impl.satellite.modem.protocol.StoGiProtocolFactory


### PR DESCRIPTION

## Commit 1 -- feat(state/tak): optional mutual TLS on the TwinManager -> TAK publisher

Opt-in mutual TLS on the existing `state.drone.tak.*` CoT publisher. Plain TCP
stays the default and is unchanged.

  * `TakProtocolDTO`: `tlsEnabled` / `tlsContext` / `keyStore` / `trustStore`
  * `state.config.TwinManagerConfig`: parse the new `tak.*` keys
  * `TakSocketConnection`: new `(host, port, SSLSocketFactory)` ctor
  * `TakTwinObserver`: build the SSLContext via `SslHelper.createContext`
  * `StateLogMessages.STATE_MANAGER_TAK_TLS_CONTEXT_FAILED`

```yaml
tak:
  tlsEnabled: true
  tlsContext: "TLSv1.2"
  keyStore:   { type: PKCS12, managerFactory: SunX509, path: ..., passphrase: ... }
  trustStore: { type: PKCS12, managerFactory: SunX509, path: ..., passphrase: ... }
```

## Commit 2 -- feat(protocol): cot -- raw Cursor-on-Target XML passthrough listener

A first-class `cot` protocol (this had been maintained out-of-tree as an SPI jar +
patch set). A client opens a `tcp://` or `ssl://` connection and streams a raw,
unframed sequence of CoT `<event>` XML documents; each complete document is
republished byte-for-byte on `/tak/cot/inbound` and, when `takHostname` is set,
relayed to a real TAK server over its own socket (plain, or mutual TLS via
commit 1).

  * `network.protocol.impl.cot.CotProtocol` / `CotProtocolFactory`
  * `config.protocol.impl.CotProtocolConfig` + `dto...impl.CotProtocolConfigDTO`
    (`takHostname` / `takPort` / `takTlsEnabled` / `takTlsContext` /
     `takKeyStore` / `takTrustStore` -- flat keys on the listener entry)
  * `EndPointConfigFactory`: `case "cot"`
  * `ProtocolImplFactory` SPI registration

`CotProtocolFactory` uses `MultiByteArrayDetection` (`<?xml` / `<event`) rather
than `NoOpDetection` so the listener is recognised on a plain `tcp://` bind, not
only behind `ssl://` where the TLS handshake substitutes for byte detection.

The session authenticates as the built-in anonymous identity (same as the
anonymous STOMP interface). Logging is via SLF4J for now -- no new
`ServerLogMessages` constants.

```yaml
- name: "TAK CoT ingest"
  url: "ssl://0.0.0.0:8089/"        # or tcp://
  protocol: cot
  auth: anon
  takHostname: takserver
  takPort: 8089
  takTlsEnabled: true
  takKeyStore:   { type: PKCS12, managerFactory: SunX509, path: ..., passphrase: ... }
  takTrustStore: { type: PKCS12, managerFactory: SunX509, path: ..., passphrase: ... }
```

## Testing

`mvn compile` clean. Exercised end-to-end against a live TAK Server 5.7: replayed
a captured RHIB track into an `ssl://` cot listener with a renamed uid + offset
coordinates; it appears as a distinct contact in TAK's `latestcot` alongside the
live track, and is echoed on `/tak/cot/inbound`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)