### PR TITLE
MSG-253 Expose drone geospatial assignments

### DIFF
--- a/src/main/java/io/mapsmessaging/state/rest/twins/DroneAdminConfigurationDTO.java
+++ b/src/main/java/io/mapsmessaging/state/rest/twins/DroneAdminConfigurationDTO.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.rest.twins;
+
+import io.mapsmessaging.state.config.DroneInfoDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Configured drone envelope used by twin administration clients.")
+public class DroneAdminConfigurationDTO {
+
+  @Schema(description = "Persisted drone metadata, including its geospatial area assignment.")
+  private DroneInfoDTO drone;
+
+  public DroneAdminConfigurationDTO() {
+  }
+
+  public DroneAdminConfigurationDTO(DroneInfoDTO drone) {
+    this.drone = drone;
+  }
+
+  public DroneInfoDTO getDrone() {
+    return drone;
+  }
+
+  public void setDrone(DroneInfoDTO drone) {
+    this.drone = drone;
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/rest/twins/TwinAdminApi.java
+++ b/src/main/java/io/mapsmessaging/state/rest/twins/TwinAdminApi.java
@@ -1,0 +1,130 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.rest.twins;
+
+import io.mapsmessaging.rest.api.impl.BaseRestApi;
+import io.mapsmessaging.rest.responses.StatusResponse;
+import io.mapsmessaging.state.config.DroneInfoDTO;
+import io.mapsmessaging.state.config.TwinManagerConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static io.mapsmessaging.rest.api.Constants.URI_PATH;
+
+@Tag(
+    name = "Server Twin Administration",
+    description = "Read-only compatibility endpoints for clients consuming configured twin metadata."
+)
+@Path(URI_PATH + "/server/twin/admin")
+public class TwinAdminApi extends BaseRestApi {
+
+  private static final String RESOURCE = "server/twin";
+
+  @GET
+  @Path("/drones")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "List configured drones",
+      description = "Returns configured drone metadata in the envelope used by twin administration clients.",
+      responses = {
+          @ApiResponse(
+              responseCode = "200",
+              description = "Configured drones returned",
+              content = @Content(
+                  mediaType = "application/json",
+                  array = @ArraySchema(schema = @Schema(implementation = DroneAdminConfigurationDTO.class))
+              )
+          ),
+          @ApiResponse(
+              responseCode = "401",
+              description = "Invalid credentials or unauthorized access",
+              content = @Content(mediaType = "application/json", schema = @Schema(implementation = StatusResponse.class))
+          ),
+          @ApiResponse(
+              responseCode = "403",
+              description = "User is not authorised to access the resource",
+              content = @Content(mediaType = "application/json", schema = @Schema(implementation = StatusResponse.class))
+          ),
+          @ApiResponse(
+              responseCode = "500",
+              description = "Server twin configuration error",
+              content = @Content(mediaType = "application/json", schema = @Schema(implementation = StatusResponse.class))
+          )
+      }
+  )
+  public Response listDrones() {
+    try {
+      hasAccess(RESOURCE);
+      TwinManagerConfig config = TwinManagerConfig.getInstance();
+      if (config == null) {
+        return internalServerError("TwinManager configuration is not available");
+      }
+      Collection<DroneInfoDTO> drones = new TwinConfigurationStore(config).listDrones();
+      return ok(toAdminDroneConfigurations(drones));
+    } catch (WebApplicationException ex) {
+      return mapAuthOrRethrow(ex);
+    } catch (Exception ex) {
+      return internalServerError("Server twin configuration error");
+    }
+  }
+
+  static List<DroneAdminConfigurationDTO> toAdminDroneConfigurations(
+      Collection<DroneInfoDTO> drones) {
+    if (drones == null) {
+      return List.of();
+    }
+    return drones.stream()
+        .filter(Objects::nonNull)
+        .map(DroneAdminConfigurationDTO::new)
+        .toList();
+  }
+
+  private Response mapAuthOrRethrow(WebApplicationException exception) {
+    Response authResponse = exception.getResponse();
+    int status = authResponse == null ? 500 : authResponse.getStatus();
+    if (status == 401) {
+      return Response.status(Response.Status.UNAUTHORIZED)
+          .entity(new StatusResponse("Unauthorized"))
+          .type(MediaType.APPLICATION_JSON)
+          .build();
+    }
+    if (status == 403) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(new StatusResponse("Access denied"))
+          .type(MediaType.APPLICATION_JSON)
+          .build();
+    }
+    throw exception;
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/rest/twins/TwinAdminApiTest.java
+++ b/src/test/java/io/mapsmessaging/state/rest/twins/TwinAdminApiTest.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.rest.twins;
+
+import io.mapsmessaging.rest.ApiTestBase;
+import io.mapsmessaging.state.config.DroneInfoDTO;
+import io.mapsmessaging.state.mavlink.model.impl.uav.GenericPx4UavModel;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static io.mapsmessaging.rest.api.Constants.URI_PATH;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class TwinAdminApiTest extends ApiTestBase {
+
+  private static final String ADMIN_BASE_PATH = URI_PATH + "/server/twin/admin";
+  private static final String CONFIG_BASE_PATH = URI_PATH + "/server/twin/config";
+
+  @Test
+  void listDrones_returnsConfiguredDroneEnvelope() {
+    String name = "it_admin_drone_" + UUID.randomUUID();
+    UUID uuid = UUID.randomUUID();
+    String body = """
+        {
+          "name": "%s",
+          "uuid": "%s",
+          "modelName": "%s"
+        }
+        """.formatted(name, uuid, GenericPx4UavModel.MODEL_NAME);
+
+    try {
+      givenAuthenticated()
+          .contentType(ContentType.JSON)
+          .body(body)
+          .when()
+          .post(CONFIG_BASE_PATH + "/drone-info")
+          .then()
+          .statusCode(201);
+
+      givenAuthenticated()
+          .when()
+          .get(ADMIN_BASE_PATH + "/drones")
+          .then()
+          .statusCode(200)
+          .contentType(ContentType.JSON)
+          .body("$", notNullValue())
+          .body("find { it.drone.name == '" + name + "' }.drone.uuid", equalTo(uuid.toString()));
+    } finally {
+      givenAuthenticatedNoValidation()
+          .when()
+          .delete(CONFIG_BASE_PATH + "/drone-info/" + name);
+    }
+  }
+
+  @Test
+  void toAdminDroneConfigurations_preservesGeospatialAssignment() {
+    DroneInfoDTO drone = new DroneInfoDTO();
+    drone.setName("USV-001");
+    drone.setUuid(UUID.randomUUID());
+    drone.setGeospatialArea("sesimbra-usv");
+
+    List<DroneAdminConfigurationDTO> response =
+        TwinAdminApi.toAdminDroneConfigurations(List.of(drone));
+
+    assertEquals(1, response.size());
+    assertSame(drone, response.get(0).getDrone());
+    assertEquals("sesimbra-usv", response.get(0).getDrone().getGeospatialArea());
+  }
+}


### PR DESCRIPTION
## Summary
- add `GET /api/v1/server/twin/admin/drones`
- return configured drones in the `{ "drone": ... }` envelope consumed by `stanag_web_viewer`
- preserve `geospatialArea` from `TwinManagerConfig.droneInfo`
- cover route registration, response shape, and assignment mapping

## Jira
[MSG-253](https://mapsmessaging.atlassian.net/browse/MSG-253)

## Validation
- server CI requested on this PR

[MSG-253]: https://mapsmessaging.atlassian.net/browse/MSG-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ