### PR TITLE
test(protocol): correct functional test observations and diagnostics

### DIFF
--- a/src/test/java/io/mapsmessaging/aggregator/StaticAggregatorOutboundTransformationSystemTest.java
+++ b/src/test/java/io/mapsmessaging/aggregator/StaticAggregatorOutboundTransformationSystemTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * - Expected final output is a flat JSON object containing:
  *     { "runId": "...", "temp": 20, "humidity": 60, "pressure": 990 }
  *
- * This test is expected to FAIL until aggregator-3 outbound transformers are configured.
+ * Aggregator-3 outbound transformers are configured in the test AggregatorManager.yaml.
  */
 class StaticAggregatorOutboundTransformationSystemTest extends BaseAggreagtorTest {
 
@@ -118,21 +118,26 @@ class StaticAggregatorOutboundTransformationSystemTest extends BaseAggreagtorTes
         return;
       }
 
-      if (!JSON_CONTENT_TYPE.equals(message.getContentType())) {
-        return;
-      }
+
 
       byte[] bytes = message.getOpaqueData();
       if (bytes == null) {
+        outQueue.offer(message);
         return;
       }
 
       String json = toUtf8(bytes);
 
-      // Keep this filter: server is long-running and other tests exist.
-      // Recommendation: keep runId in the outbound flattened output.
-      if (!json.contains("\"runId\":\"" + runId + "\"")) {
-        return;
+      // Ignore another run only when its identity can be established structurally.
+      // Preserve malformed or incomplete output for the assertions below.
+      try {
+        Map<String, Object> output = gson.fromJson(json, mapType);
+        if (output != null && output.containsKey("runId") && output.get("runId") != null
+            && !runId.equals(output.get("runId"))) {
+          return;
+        }
+      } catch (com.google.gson.JsonParseException ignored) {
+        // The test must report malformed output instead of a misleading timeout.
       }
 
       outQueue.offer(message);

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/conformance/PahoConformance.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/conformance/PahoConformance.java
@@ -67,17 +67,33 @@ abstract class PahoConformance extends BaseTestConfig {
 
     StreamReader errReader =new StreamReader(process.getErrorStream());
 
-    process.waitFor();
+    int exitCode;
+    try {
+      exitCode = process.waitFor();
+      outputReader.thread.join();
+      errReader.thread.join();
+    } catch (InterruptedException exception) {
+      process.destroyForcibly();
+      Thread.currentThread().interrupt();
+      throw exception;
+    }
+    if (outputReader.failure != null) {
+      throw outputReader.failure;
+    }
+    if (errReader.failure != null) {
+      throw errReader.failure;
+    }
     System.err.println(outputReader.sb);
     System.err.println(errReader.sb);
-    boolean result = !outputReader.sb.toString().contains("FAIL") && !errReader.sb.toString().contains("FAIL");
+    boolean result = exitCode == 0 && !outputReader.sb.toString().contains("FAIL") && !errReader.sb.toString().contains("FAIL");
     for(String exception:EXCEPTIONS){
       if(testName.equals(exception)){
         System.err.println("Ignoring result of test since test is in exclusion list");
         Assumptions.assumeTrue(result);
       }
     }
-    Assertions.assertTrue(result);
+    Assertions.assertTrue(result, "Paho " + testName + " exited with " + exitCode
+        + "\nstdout:\n" + outputReader.sb + "\nstderr:\n" + errReader.sb);
   }
 
   private List<String> scanForTests(File pythonSource) throws IOException {
@@ -107,13 +123,15 @@ abstract class PahoConformance extends BaseTestConfig {
 
     private final InputStream is;
     private final StringBuilder sb;
+    private final Thread thread;
+    private IOException failure;
 
     public StreamReader(InputStream is){
       this.is = is;
       sb = new StringBuilder();
-      Thread outputReaderThread = new Thread(this);
-      outputReaderThread.setDaemon(true);
-      outputReaderThread.start();
+      thread = new Thread(this);
+      thread.setDaemon(true);
+      thread.start();
     }
 
     @Override
@@ -129,6 +147,7 @@ abstract class PahoConformance extends BaseTestConfig {
             return;
           }
         } catch (IOException e) {
+          failure = e;
           return;
         }
       }

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/ComplianceTests.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/ComplianceTests.java
@@ -183,40 +183,46 @@ class ComplianceTests extends MQTTBaseTest{
 
     aclient.connect(options);
 
-    MqttSubscription[] subscriptions = new MqttSubscription[1];
-    TestListener[] listeners = new TestListener[1];
-    subscriptions[0] = new MqttSubscription("TopicA", 2);
-    subscriptions[0].setNoLocal(false);
-    listeners[0] = new TestListener();
-    aclient.subscribe(subscriptions, listeners);
+    try {
+      String topic = "test/payload-format/" + UuidGenerator.getInstance().generate();
+      MqttSubscription subscription = new MqttSubscription(topic, 2);
+      subscription.setNoLocal(false);
+      aclient.subscribe(new MqttSubscription[]{subscription});
 
+      MqttProperties properties = new MqttProperties();
+      properties.setPayloadFormat(true);
+      properties.setContentType("My name");
 
-    MqttProperties properties = new MqttProperties();
-    properties.setPayloadFormat(true);
-    properties.setContentType("My name");
+      for (int qos = 0; qos <= 2; qos++) {
+        MqttMessage message = new MqttMessage(new byte[0]);
+        message.setQos(qos);
+        message.setRetained(false);
+        message.setProperties(properties);
+        aclient.publish(topic, message);
+      }
 
-    for (int qos = 0; qos <= 2; qos++) {
-      MqttMessage message = new MqttMessage("".getBytes(StandardCharsets.UTF_8));
-      message.setQos(qos);
-      message.setRetained(false);
-      message.setProperties(properties);
-      aclient.publish("TopicA", message);
-    }
+      int retries = 0;
+      while (callback.counter.get() < 3 && retries++ < 30) {
+        Thread.sleep(100);
+      }
 
-    int retries = 0;
-    while (callback.counter.get() < 3 && retries++ < 30) {
-      Thread.sleep(100);
-    }
-
-    aclient.disconnect();
-
-    Assertions.assertEquals(3, callback.counter.get(), "Expected 3 messages");
-
-    for (int i = 0; i < callback.messages.length && callback.messages[i] != null; i++) {
-      MqttMessage msg = callback.messages[i];
-      MqttProperties props = msg.getProperties();
-      Assertions.assertEquals("My name", props.getContentType());
-      Assertions.assertEquals(true, props.getPayloadFormat());
+      aclient.disconnect();
+      Assertions.assertEquals(3, callback.counter.get(), "Expected 3 messages");
+      for (int index = 0; index < 3; index++) {
+        MqttMessage message = callback.messages[index];
+        Assertions.assertNotNull(message, "Missing received message " + index);
+        Assertions.assertEquals(0, message.getPayload().length);
+        Assertions.assertEquals("My name", message.getProperties().getContentType());
+        Assertions.assertEquals(true, message.getProperties().getPayloadFormat());
+      }
+    } finally {
+      try {
+        if (aclient.isConnected()) {
+          aclient.disconnect();
+        }
+      } finally {
+        aclient.close();
+      }
     }
   }
 

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/SimpleOverlapTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/mqtt5/SimpleOverlapTest.java
@@ -132,76 +132,83 @@ class SimpleOverlapTest extends MQTTBaseTest {
     });
     String[] topics = {"overlap/topic1", "overlap/topic2", "overlap/topic3"};
     client.connect(options);
-    //
-    // Create 3 topics
-    subscribe(client, "overlap/topic1", counter, QoS);
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 1));
+    try {
+      //
+      // Create 3 topics
+      subscribe(client, "overlap/topic1", QoS);
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 1));
 
-    subscribe(client, "overlap/topic2", counter, QoS);
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 2));
+      subscribe(client, "overlap/topic2", QoS);
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 2));
 
-    subscribe(client, "overlap/topic3", counter, QoS);
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 3));
+      subscribe(client, "overlap/topic3", QoS);
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 3));
 
-    //
-    // Create the wildcard subscription
-    subscribe(client, "overlap/#", counter, QoS);
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 3));
+      //
+      // Create the wildcard subscription
+      subscribe(client, "overlap/#", QoS);
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 3));
 
-    //
-    // Unsubscribe from 2
-    client.unsubscribe("overlap/topic2");
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 3));
+      //
+      // Unsubscribe from 2
+      client.unsubscribe("overlap/topic2");
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 3));
 
-    client.unsubscribe("overlap/topic3");
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 3));
+      client.unsubscribe("overlap/topic3");
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 3));
 
-    //
-    // Unsubscribe from the first topic
-    client.unsubscribe("overlap/topic1");
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 3));
+      //
+      // Unsubscribe from the first topic
+      client.unsubscribe("overlap/topic1");
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 3));
 
-    //
-    // Unsubscribe from the wildcard
-    client.unsubscribe("overlap/#");
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 0));
+      //
+      // Unsubscribe from the wildcard
+      client.unsubscribe("overlap/#");
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 0));
 
-    //
-    // Now subscribe to the wildcard
-    subscribe(client, "overlap/#", counter, QoS);
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 3));
+      //
+      // Now subscribe to the wildcard
+      subscribe(client, "overlap/#", QoS);
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 3));
 
-    subscribe(client, "overlap/topic1", counter, QoS);
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 3));
+      subscribe(client, "overlap/topic1", QoS);
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 3));
 
-    client.unsubscribe("overlap/#");
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 1));
+      client.unsubscribe("overlap/#");
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 1));
 
-    client.unsubscribe("overlap/topic1");
-    publish(client, topics, QoS);
-    Assertions.assertTrue(waitFor(counter, 0));
-    client.disconnect();
-    client.close();
+      client.unsubscribe("overlap/topic1");
+      publish(client, topics, QoS);
+      Assertions.assertTrue(waitFor(counter, 0));
+    } finally {
+      try {
+        if (client.isConnected()) {
+          client.disconnect();
+        }
+      } finally {
+        client.close();
+      }
+    }
   }
 
 
-  private void subscribe(MqttClient mqttClient, String topic, AtomicInteger counter, int QoS) throws MqttException {
+  private void subscribe(MqttClient mqttClient, String topic, int QoS) throws MqttException {
     MqttSubscription[] subscriptions = new MqttSubscription[1];
-    IMqttMessageListener[] listeners = new IMqttMessageListener[1];
     subscriptions[0] = new MqttSubscription(topic, QoS);
-    listeners[0] = (s, mqttMessage) -> counter.incrementAndGet();
-    mqttClient.subscribe(subscriptions, listeners);
+    mqttClient.subscribe(subscriptions);
+
   }
 
 

--- a/src/test/java/io/mapsmessaging/network/protocol/impl/nats/conv/HighFanoutOrderingTest.java
+++ b/src/test/java/io/mapsmessaging/network/protocol/impl/nats/conv/HighFanoutOrderingTest.java
@@ -43,7 +43,7 @@ class HighFanoutOrderingTest extends BaseTestConfig {
     final int nSubs = 100;
     final int nPubs = 500;
 
-    final AtomicInteger[] counters = new AtomicInteger[nConns];
+    final AtomicInteger orderingErrors = new AtomicInteger();
 
     String url = "nats://localhost:4222";
     String subject = "test.inbox." + System.nanoTime();
@@ -59,10 +59,7 @@ class HighFanoutOrderingTest extends BaseTestConfig {
         Connection conn = Nats.connect(new Options.Builder().server(url).build());
         connections.add(conn);
 
-        AtomicInteger local = new AtomicInteger();
-        counters[i] = local;
-
-        Dispatcher dispatcher = conn.createDispatcher(msg -> local.incrementAndGet());
+        Dispatcher dispatcher = conn.createDispatcher(msg -> orderingErrors.incrementAndGet());
         dispatchers.add(dispatcher);
 
         for (int j = 0; j < nSubs; j++) {
@@ -71,11 +68,18 @@ class HighFanoutOrderingTest extends BaseTestConfig {
           dispatcher.subscribe(subject, msg -> {
             int val = Integer.parseInt(new String(msg.getData()));
             int exp = expected.getAndIncrement();
-            if (val == exp && exp + 1 == nPubs) {
+            if (val != exp) {
+              orderingErrors.incrementAndGet();
+            }
+            if (exp + 1 == nPubs) {
               latch.countDown();
             }
           });
         }
+      }
+
+      for (Connection connection : connections) {
+        connection.flush(Duration.ofSeconds(30));
       }
 
       publisherConnection = Nats.connect(new Options.Builder().server(url).build());
@@ -85,7 +89,8 @@ class HighFanoutOrderingTest extends BaseTestConfig {
       publisherConnection.flush(Duration.ofSeconds(30));
 
       boolean completed = latch.await(30, TimeUnit.SECONDS);
-      assertEquals(true, completed, "Not all subscriptions received ordered messages");
+      assertEquals(true, completed, "Not all subscriptions received all messages");
+      assertEquals(0, orderingErrors.get(), "Subscriptions received out-of-order messages");
     }
     finally {
       if (publisherConnection != null) {
@@ -94,7 +99,7 @@ class HighFanoutOrderingTest extends BaseTestConfig {
 
       for (int i = 0; i < connections.size(); i++) {
         Connection conn = connections.get(i);
-        Dispatcher dispatcher = dispatchers.get(i);
+        Dispatcher dispatcher = i < dispatchers.size() ? dispatchers.get(i) : null;
 
         if (dispatcher != null) {
           conn.closeDispatcher(dispatcher);


### PR DESCRIPTION
## Why
Functional CI failures include incorrect receiver counting and diagnostics that hide the point of failure. This cleanup preserves regression coverage while making remaining failures actionable.

## Changes
- MQTT 5 payload-format test observes the global receiver without a competing subscription listener, checks every expected payload/property, isolates its topic and closes the client on failure.
- MQTT 5 overlap test counts incoming publications through one callback while retaining all subscription/unsubscribe expected counts; closes its client on assertion failure.
- Aggregator test correlates JSON structurally and exposes missing/malformed output and content-type errors to assertions; removes stale expected-failure comment.
- NATS fanout waits for subscriber flush before publication and remembers earlier order mismatches; improves partial-setup cleanup.
- Paho wrapper joins output readers and checks exit status, preserving subprocess failure details and existing exclusions.

## Validation
- git diff --check passed.
- Java compiler parser accepted all five changed source files (syntax only, using installed JDK 17; no type checking).
- Attempted focused Maven tests with available Java 21 toolchain, but POM resolution failed before compilation: AWS SDK BOM 2.46.15 and Jersey BOM 4.0.2 unavailable due repository/DNS access. Further inspection also found the available Java 21 toolchain's module image inconsistent; it is not a reliable validation environment.
- No runtime pass claimed. Draft pending Jenkins verification.

## Remaining investigation
Paho flow_control2 broken pipe, NATS flush timeout, CANAerospace/N2K ingestion and extra authentication/system-topic failures remain unresolved. No production defect is asserted from timeout evidence alone. No tests disabled or deleted; REST schema failures excluded.

Jira: https://mapsmessaging.atlassian.net/browse/MSG-263
Refs: MSG-263