### PR TITLE
feat(rest): serve drone administration at /admin/

### DIFF
--- a/src/main/java/io/mapsmessaging/rest/RestApiServerManager.java
+++ b/src/main/java/io/mapsmessaging/rest/RestApiServerManager.java
@@ -291,7 +291,11 @@ public class RestApiServerManager implements Agent {
             String uriMapping = file.getName().equals("admin") ? "/" : "/" + file.getName() + "/";
             StaticHttpHandler staticHttpHandler = new CorsEnabledStaticHttpHandler(location + File.separator);
             staticHttpHandler.setFileCacheEnabled(true);
-            server.getServerConfiguration().addHttpHandler(staticHttpHandler, uriMapping + "*");
+            if (file.getName().equals("drone-admin")) {
+              server.getServerConfiguration().addHttpHandler(staticHttpHandler, "/admin/*", uriMapping + "*");
+            } else {
+              server.getServerConfiguration().addHttpHandler(staticHttpHandler, uriMapping + "*");
+            }
           }
         }
       }


### PR DESCRIPTION
Withdrawn following clarification: keep drone administration at /drone-admin/. No server routing changes are required. MSG-264 is limited to adding the operational viewer at /cob/ in stanag-drone-package PR #9.

Refs: MSG-264