### PR TITLE
fix(buildkite): shorten Windows MSI packaging paths

### DIFF
--- a/packaging/windows/windows_packager.ps1
+++ b/packaging/windows/windows_packager.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = 'Stop'
+
 $Username = $args[0]
 $Password = $args[1]
 $Version = $args[2]
@@ -45,69 +47,104 @@ $ZipName = "maps-$Version-install.zip"
 $ZipUrl = "https://github.com/Maps-Messaging/mapsmessaging_server/releases/download/$Version/$ZipName"
 $PushUrl = "https://repository.mapsmessaging.io/service/rest/v1/components?repository=$PushRepo"
 
-Write-Host "Downloading $ZipUrl"
-Invoke-WebRequest -Uri $ZipUrl -OutFile $ZipName -UseBasicParsing
+# Keep extraction and staging paths short even under a deep Buildkite checkout.
+# Each invocation owns its directory so parallel agents and retries cannot collide.
+$WorkRoot = Join-Path $env:SystemDrive "b"
+New-Item -ItemType Directory -Path $WorkRoot -Force | Out-Null
+$WorkDir = Join-Path $WorkRoot ([Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $WorkDir | Out-Null
+$LocationPushed = $false
 
-$InputDir = "maps-$Version"
-Expand-Archive -Path $ZipName -DestinationPath "." -Force
+try {
+    foreach ($file in @("build-windows-package.ps1", "jdk_copy.ps1", "jpackage_script.ps1", "mapsTop.properties")) {
+        Copy-Item -LiteralPath (Join-Path $PSScriptRoot $file) -Destination $WorkDir
+    }
+    Push-Location -LiteralPath $WorkDir
+    $LocationPushed = $true
+    Write-Host "Windows packaging workspace: $WorkDir"
 
-.\build-windows-package.ps1 -Version $Version -AppName $AppName
+    Write-Host "Downloading $ZipUrl"
+    Invoke-WebRequest -Uri $ZipUrl -OutFile $ZipName -UseBasicParsing
 
-$InstallerPath = Get-ChildItem -Path "out\win" -Filter "$AppName*.msi" | Select-Object -First 1
+    $InputDir = "maps-$Version"
+    Expand-Archive -Path $ZipName -DestinationPath "." -Force
 
-if ($InstallerPath) {
-    $encodedCreds = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("$Username`:$Password"))
-    $filename = $InstallerPath.Name
-    $directory = "windows/$Version"
-
-    $searchUrl = "https://repository.mapsmessaging.io/service/rest/v1/search?repository=$PushRepo&name=$($InstallerPath.BaseName)&version=$Version"
-    try {
-        $response = Invoke-RestMethod -Uri $searchUrl -Headers @{ Authorization = "Basic $encodedCreds" } -Method Get
-        if ($response.items.Count -gt 0) {
-            $componentId = $response.items[0].id
-            $deleteUrl = "https://repository.mapsmessaging.io/service/rest/v1/components/$componentId"
-            Invoke-RestMethod -Uri $deleteUrl -Headers @{ Authorization = "Basic $encodedCreds" } -Method Delete
-            Write-Host "Deleted existing component ID: $componentId"
-        } else {
-            Write-Host "No existing package found to delete."
-        }
-    } catch {
-        Write-Warning "Failed to query/delete existing component: $_"
+    .\build-windows-package.ps1 -Version $Version -AppName $AppName
+    if ($LASTEXITCODE -ne 0) {
+        throw "Windows packaging failed with exit code $LASTEXITCODE"
     }
 
-    $boundary = [System.Guid]::NewGuid().ToString()
-    $fileBytes = [System.IO.File]::ReadAllBytes($InstallerPath.FullName)
-    $crlf = "`r`n"
+    $InstallerPath = Get-ChildItem -Path "out\win" -Filter "$AppName*.msi" | Select-Object -First 1
 
-    $stream = New-Object System.IO.MemoryStream
-    $writer = New-Object System.IO.StreamWriter($stream, [System.Text.Encoding]::ASCII)
+    if ($InstallerPath) {
+        # Retain the existing artifact location for Buildkite and local callers.
+        $ArtifactDir = Join-Path $PSScriptRoot "out\win"
+        New-Item -ItemType Directory -Path $ArtifactDir -Force | Out-Null
+        Copy-Item -LiteralPath $InstallerPath.FullName -Destination $ArtifactDir -Force
 
-    $writer.Write("--$boundary$crlf")
-    $writer.Write("Content-Disposition: form-data; name=`"raw.directory`"$crlf$crlf")
-    $writer.Write("$directory$crlf")
+        $encodedCreds = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("$Username`:$Password"))
+        $filename = $InstallerPath.Name
+        $directory = "windows/$Version"
 
-    $writer.Write("--$boundary$crlf")
-    $writer.Write("Content-Disposition: form-data; name=`"raw.asset1`"; filename=`"$filename`"$crlf")
-    $writer.Write("Content-Type: application/octet-stream$crlf$crlf")
-    $writer.Flush()
+        $searchUrl = "https://repository.mapsmessaging.io/service/rest/v1/search?repository=$PushRepo&name=$($InstallerPath.BaseName)&version=$Version"
+        try {
+            $response = Invoke-RestMethod -Uri $searchUrl -Headers @{ Authorization = "Basic $encodedCreds" } -Method Get
+            if ($response.items.Count -gt 0) {
+                $componentId = $response.items[0].id
+                $deleteUrl = "https://repository.mapsmessaging.io/service/rest/v1/components/$componentId"
+                Invoke-RestMethod -Uri $deleteUrl -Headers @{ Authorization = "Basic $encodedCreds" } -Method Delete
+                Write-Host "Deleted existing component ID: $componentId"
+            } else {
+                Write-Host "No existing package found to delete."
+            }
+        } catch {
+            Write-Warning "Failed to query/delete existing component: $_"
+        }
 
-    $stream.Write($fileBytes, 0, $fileBytes.Length)
+        $boundary = [System.Guid]::NewGuid().ToString()
+        $fileBytes = [System.IO.File]::ReadAllBytes($InstallerPath.FullName)
+        $crlf = "`r`n"
 
-    $writer = New-Object System.IO.StreamWriter($stream, [System.Text.Encoding]::ASCII, 1024, $true)
-    $writer.Write("$crlf--$boundary$crlf")
-    $writer.Write("Content-Disposition: form-data; name=`"raw.asset1.filename`"$crlf$crlf")
-    $writer.Write("$filename$crlf")
-    $writer.Write("--$boundary--$crlf")
-    $writer.Flush()
+        $stream = New-Object System.IO.MemoryStream
+        $writer = New-Object System.IO.StreamWriter($stream, [System.Text.Encoding]::ASCII)
 
-    $body = $stream.ToArray()
+        $writer.Write("--$boundary$crlf")
+        $writer.Write("Content-Disposition: form-data; name=`"raw.directory`"$crlf$crlf")
+        $writer.Write("$directory$crlf")
 
-    Invoke-WebRequest -Uri $PushUrl `
-                      -Method Post `
-                      -Headers @{ Authorization = "Basic $encodedCreds"; "Content-Type" = "multipart/form-data; boundary=$boundary" } `
-                      -Body $body
+        $writer.Write("--$boundary$crlf")
+        $writer.Write("Content-Disposition: form-data; name=`"raw.asset1`"; filename=`"$filename`"$crlf")
+        $writer.Write("Content-Type: application/octet-stream$crlf$crlf")
+        $writer.Flush()
 
-    Write-Host "Uploaded $filename to Nexus repo $PushRepo"
-} else {
-    Write-Error "Installer not found."
+        $stream.Write($fileBytes, 0, $fileBytes.Length)
+
+        $writer = New-Object System.IO.StreamWriter($stream, [System.Text.Encoding]::ASCII, 1024, $true)
+        $writer.Write("$crlf--$boundary$crlf")
+        $writer.Write("Content-Disposition: form-data; name=`"raw.asset1.filename`"$crlf$crlf")
+        $writer.Write("$filename$crlf")
+        $writer.Write("--$boundary--$crlf")
+        $writer.Flush()
+
+        $body = $stream.ToArray()
+
+        Invoke-WebRequest -Uri $PushUrl `
+                          -Method Post `
+                          -Headers @{ Authorization = "Basic $encodedCreds"; "Content-Type" = "multipart/form-data; boundary=$boundary" } `
+                          -Body $body
+
+        Write-Host "Uploaded $filename to Nexus repo $PushRepo"
+    } else {
+        Write-Error "Installer not found."
+    }
+
+} finally {
+    if ($LocationPushed) {
+        Pop-Location
+    }
+    try {
+        Remove-Item -LiteralPath $WorkDir -Recurse -Force -ErrorAction Stop
+    } catch {
+        Write-Warning "Could not remove packaging workspace '$WorkDir': $_"
+    }
 }


### PR DESCRIPTION
The AWS Windows checkout makes deeply nested ZIP entries exceed the traditional Windows path limit. Extraction fails and packaging continues with misleading missing-file errors.

This changes only packaging/windows/windows_packager.ps1. It resolves the version in the original checkout, copies the existing packaging helpers and launcher properties into a unique C:\b\<GUID> workspace, and performs extraction and staging there. Terminating PowerShell errors and a nonzero native packaging exit stop publishing. The MSI is copied back to packaging/windows/out/win, and finally restores the caller location and removes the owned workspace. Nexus upload behavior is retained.

Validation: static control-flow and upload-block preservation checks passed. The reported entry is 171 characters in extraction and 185 in staging, below 260. PowerShell is unavailable in this environment; Windows execution, actual MSI generation and Nexus upload remain to be verified by rerunning the development MSI pipeline after merge. No Maven run or Java test changes: PowerShell packaging only.

The service account needs permission to create C:\b (the current AWS worker uses the existing administrator configuration). Cleanup failures warn without hiding the original packaging error. No startup, CloudFormation, S3 or messaging protocol changes.

Refs: MSG-268