### PR TITLE
fix(mavlink): retry mission uploads rejected with invalid sequence

### DIFF
--- a/docs/mavlink/mission-upload-recovery.md
+++ b/docs/mavlink/mission-upload-recovery.md
@@ -1,0 +1,34 @@
+# Mission upload sequence recovery
+
+Refs: MSG-227
+
+An addressed, valid MISSION_ACK with MAV_MISSION_INVALID_SEQUENCE ends the
+current transfer and requests a restart from its MISSION_COUNT message.
+Sequence tracking resets to zero. The sender retains the same command set,
+registration and completion callback; it does not clear the onboard mission
+or start execution until the final accepted mission ACK.
+
+Two restarts are permitted per sender. Backoff is one then two acknowledgement
+timeout intervals (2 s then 4 s by default). Inbound packets are ignored while
+backoff is pending. Cancellation and close cancel the restart timer; generation
+checks prevent a stale timer from starting a later attempt.
+
+After the restart budget is exhausted the sender reports TIMEOUT, retaining the
+last response and an explicit exhaustion reason. The existing STANAG dispatcher
+keeps initial dispatch available for explicit resend and releases a failed resume
+attempt. Other mission rejection results still report FAILED. Normal packet-loss
+retransmission settings are unchanged. A handler without a mission prefix cannot
+restart and retains its previous failure behaviour.
+
+This is bounded transfer retry, not automatic connectivity monitoring. It does
+not wait for Starlink/cellular availability. Task cancellation must continue to
+close/cancel its registered sender. No new task expiration policy is introduced.
+The existing ANY_LOCAL_ID preparer behaviour and repeated-request no-progress
+budget remain separate follow-ups. MAVLink has no upload-attempt transaction ID;
+packets delayed beyond the backoff can still be indistinguishable from a current
+request. Backoff reduces exposure but does not provide strong correlation.
+
+Regression coverage includes restart success after partial upload, ignored
+packets during backoff, restart-budget exhaustion, cancellation during backoff,
+and scheduled restart execution. Unsupported rejection still fails without
+starting navigation.

--- a/docs/mavlink/mission-upload-recovery.md
+++ b/docs/mavlink/mission-upload-recovery.md
@@ -32,3 +32,16 @@ Regression coverage includes restart success after partial upload, ignored
 packets during backoff, restart-budget exhaustion, cancellation during backoff,
 and scheduled restart execution. Unsupported rejection still fails without
 starting navigation.
+
+While awaiting item zero, an in-range nonzero request is ignored without
+refreshing the MISSION_COUNT retry timer or resetting its retry budget. This
+covers stale requests such as sequence 6 while expecting 0, both initially and
+after a restart. Persistent stale requests therefore end in TIMEOUT rather than
+immediate task abortion. Out-of-range requests and skips after progress retain
+their existing explicit failure behaviour.
+
+When a local MAVLink identity is configured, outbound headers use that protocol
+configuration's systemId/componentId on each send. The retry path reuses the same sender and messages, without allocating a
+new identity. This does not guarantee identity consistency across independently
+configured bridge endpoints. Automatic MISSION_CLEAR_ALL is intentionally not
+used: it deletes the onboard plan and needs separate hold-state handling.

--- a/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
+++ b/src/main/java/io/mapsmessaging/state/drone/drone/DroneTwin.java
@@ -119,6 +119,12 @@ public class DroneTwin extends EntityTwin {
   @Schema(description = "Current mission execution state.", example = "ACTIVE", nullable = true)
   private String missionState;
 
+  @Schema(description = "Latest outbound MAVLink transmission snapshot, retained after completion.")
+  private volatile io.mapsmessaging.state.mavlink.sender.MavlinkTransmissionState missionTransmission;
+
+  @Schema(description = "Latest STANAG task upload retry state, retained after completion.")
+  private volatile Map<String, Object> taskTransmission;
+
   @Schema(description = "Vehicle heading in degrees.", example = "182.4", nullable = true)
   private Double headingDegrees;
 
@@ -286,7 +292,11 @@ public class DroneTwin extends EntityTwin {
   @JsonIgnore
   @Schema(hidden = true)
   public boolean registerMavlinkSender(MavlinkEventListSender sender) {
-    return activeMavlinkSender.compareAndSet(null, Objects.requireNonNull(sender, "sender must not be null"));
+    if (!activeMavlinkSender.compareAndSet(null, Objects.requireNonNull(sender, "sender must not be null"))) {
+      return false;
+    }
+    missionTransmission = sender.getTransmissionState();
+    return true;
   }
 
   @JsonIgnore

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkAcknowledgementHandler.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkAcknowledgementHandler.java
@@ -50,6 +50,10 @@ public interface MavlinkAcknowledgementHandler {
       return new Acknowledgement(Action.SEND_INDEX, index, null);
     }
 
+    public static Acknowledgement restart(int index, String reason) {
+      return new Acknowledgement(Action.RESTART, index, reason);
+    }
+
     public static Acknowledgement complete() {
       return new Acknowledgement(Action.COMPLETE, -1, null);
     }
@@ -64,6 +68,7 @@ public interface MavlinkAcknowledgementHandler {
     WAIT,
     ADVANCE,
     SEND_INDEX,
+    RESTART,
     COMPLETE,
     FAIL
   }

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
@@ -41,6 +41,7 @@ import lombok.Getter;
 public class MavlinkEventListSender implements AutoCloseable {
 
   public static final int DEFAULT_MAX_RETRIES = 3;
+  public static final int MAX_MISSION_RESTARTS = 2;
   public static final long DEFAULT_ACKNOWLEDGEMENT_TIMEOUT_MILLIS = 2_000L;
 
   private static final Logger logger = LoggerFactory.getLogger(MavlinkEventListSender.class);
@@ -62,6 +63,8 @@ public class MavlinkEventListSender implements AutoCloseable {
   private int nextIndex;
   private int waitingIndex;
   private int retryCount;
+  private int missionRestartCount;
+  private int restartIndex = -1;
   private long acknowledgementTimeoutGeneration;
   private MavlinkMessage waitingMessage;
   private MavlinkMessage lastSentMessage;
@@ -161,7 +164,17 @@ public class MavlinkEventListSender implements AutoCloseable {
   }
 
   public void timeout() {
-    processTimeout(null, null, null);
+    synchronized (inboundLock) {
+      Long restartGeneration;
+      synchronized (lock) {
+        restartGeneration = restartIndex >= 0 && !terminal ? acknowledgementTimeoutGeneration : null;
+      }
+      if (restartGeneration != null) {
+        restartMission(restartGeneration);
+      } else {
+        processTimeout(null, null, null);
+      }
+    }
   }
 
   private void processTimeout(Integer expectedIndex, MavlinkMessage expectedMessage, Long expectedGeneration) {
@@ -236,12 +249,48 @@ public class MavlinkEventListSender implements AutoCloseable {
 
       case ADVANCE -> handleAdvance(sentMessage, sentIndex);
       case SEND_INDEX -> handleSendIndex(acknowledgement.index());
+      case RESTART -> scheduleMissionRestart(acknowledgement);
 
       case COMPLETE ->
           complete(MavlinkSendResult.Status.SUCCESS, sentIndex, sentMessage, receivedMessage, null, "MAVLink event list sender completed successfully");
 
       case FAIL ->
           complete(MavlinkSendResult.Status.FAILED, sentIndex, sentMessage, receivedMessage, null, failureReason(acknowledgement));
+    }
+  }
+
+  private void scheduleMissionRestart(Acknowledgement acknowledgement) {
+    synchronized (lock) {
+      if (terminal) {
+        return;
+      }
+      if (missionRestartCount >= MAX_MISSION_RESTARTS) {
+        complete(MavlinkSendResult.Status.TIMEOUT, waitingIndex, waitingMessage, lastReceivedMessage,
+            null, "Mission upload restart budget exhausted after INVALID_SEQUENCE");
+        return;
+      }
+      clearWaitingState();
+      restartIndex = acknowledgement.index();
+      missionRestartCount++;
+      long generation = acknowledgementTimeoutGeneration;
+      acknowledgementTimeoutFuture = SimpleTaskScheduler.getInstance().schedule(
+          () -> restartMission(generation), acknowledgementTimeoutMillis * missionRestartCount,
+          TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void restartMission(long generation) {
+    synchronized (inboundLock) {
+      int index;
+      synchronized (lock) {
+        if (terminal || restartIndex < 0 || generation != acknowledgementTimeoutGeneration) {
+          return;
+        }
+        index = restartIndex;
+        restartIndex = -1;
+        cancelAcknowledgementTimeout();
+      }
+      handleSendIndex(index);
     }
   }
 
@@ -427,6 +476,7 @@ public class MavlinkEventListSender implements AutoCloseable {
     cancelAcknowledgementTimeout();
     waitingMessage = null;
     waitingIndex = -1;
+    restartIndex = -1;
     retryCount = 0;
   }
 

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSender.java
@@ -58,6 +58,19 @@ public class MavlinkEventListSender implements AutoCloseable {
   private final long acknowledgementTimeoutMillis;
   private final AtomicBoolean isActive = new AtomicBoolean(true);
 
+  private final MavlinkTransmissionState transmissionState = new MavlinkTransmissionState();
+  private final int missionItemTotal;
+  private long sendAttempts;
+  private long totalPacketRetries;
+  private Long transmissionStartedAt;
+  private Long lastSentAt;
+  private Long lastResponseAt;
+  private Integer lastMissionSequence;
+  private Long nextRetryAt;
+  private String transmissionStatus = "PREPARED";
+  private String transmissionReason;
+  private int transmissionMessageIndex = -1;
+
   private boolean started;
   private boolean terminal;
   private int nextIndex;
@@ -109,6 +122,9 @@ public class MavlinkEventListSender implements AutoCloseable {
     this.maxRetries = maxRetries;
     this.acknowledgementTimeoutMillis = acknowledgementTimeoutMillis;
     this.waitingIndex = -1;
+    this.missionItemTotal = (int) messages.stream().filter(message ->
+        message instanceof io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemInt
+            || message instanceof io.mapsmessaging.state.mavlink.messages.MavlinkMissionItem).count();
 
     logger.log(MAVLINK_EVENT_LIST_SENDER_CREATED, sequenceId, commandSet.operation(), commandSet.modelName(), messages.size());
   }
@@ -124,6 +140,8 @@ public class MavlinkEventListSender implements AutoCloseable {
         return;
       }
       started = true;
+      transmissionStartedAt = System.currentTimeMillis();
+      updateTransmission("STARTING", null);
     }
 
     logger.log(MAVLINK_EVENT_LIST_SENDER_STARTING, sequenceId, commandSet.operation(), commandSet.modelName());
@@ -204,6 +222,8 @@ public class MavlinkEventListSender implements AutoCloseable {
 
       if (!retriesExhausted) {
         retryCount++;
+        totalPacketRetries++;
+        updateTransmission("RETRYING", "Response timeout; retransmitting current message");
       }
     }
 
@@ -234,6 +254,8 @@ public class MavlinkEventListSender implements AutoCloseable {
     if (action != Action.NOT_RELATED) {
       synchronized (lock) {
         lastReceivedMessage = receivedMessage;
+        lastResponseAt = System.currentTimeMillis();
+        updateTransmission(transmissionStatus, acknowledgement.reason());
       }
     }
 
@@ -272,6 +294,8 @@ public class MavlinkEventListSender implements AutoCloseable {
       clearWaitingState();
       restartIndex = acknowledgement.index();
       missionRestartCount++;
+      nextRetryAt = System.currentTimeMillis() + acknowledgementTimeoutMillis * missionRestartCount;
+      updateTransmission("RESTART_BACKOFF", "INVALID_SEQUENCE; restarting mission upload");
       long generation = acknowledgementTimeoutGeneration;
       acknowledgementTimeoutFuture = SimpleTaskScheduler.getInstance().schedule(
           () -> restartMission(generation), acknowledgementTimeoutMillis * missionRestartCount,
@@ -417,6 +441,16 @@ public class MavlinkEventListSender implements AutoCloseable {
     logger.log(MAVLINK_EVENT_LIST_SENDER_SENDING, sequenceId, commandSet.operation(), commandSet.modelName(), index + 1, messages.size(), messageName(message), requiresAcknowledgement);
     synchronized (lock) {
       lastSentMessage = message;
+      transmissionMessageIndex = index;
+      sendAttempts++;
+      lastSentAt = System.currentTimeMillis();
+      if (message instanceof io.mapsmessaging.state.mavlink.messages.MavlinkMissionItemInt item) {
+        lastMissionSequence = item.getMissionSequence();
+      } else if (message instanceof io.mapsmessaging.state.mavlink.messages.MavlinkMissionItem item) {
+        lastMissionSequence = item.getMissionSequence();
+      }
+      nextRetryAt = requiresAcknowledgement ? lastSentAt + acknowledgementTimeoutMillis : null;
+      updateTransmission(requiresAcknowledgement ? "WAITING_RESPONSE" : "SENDING", null);
     }
     sender.send(message);
 
@@ -502,6 +536,8 @@ public class MavlinkEventListSender implements AutoCloseable {
       }
 
       terminal = true;
+      nextRetryAt = null;
+      updateTransmission(status.name(), reason);
       clearWaitingState();
       MavlinkMessage retainedSentMessage = sentMessage == null ? lastSentMessage : sentMessage;
       MavlinkPacket retainedReceivedMessage = receivedMessage == null ? lastReceivedMessage : receivedMessage;
@@ -554,6 +590,25 @@ public class MavlinkEventListSender implements AutoCloseable {
     if (result.cause() != null) {
       logger.log(MAVLINK_EVENT_LIST_SENDER_FAILED_EXCEPTION, sequenceId, commandSet.operation(), commandSet.modelName(), result.cause().getMessage());
     }
+  }
+
+  public MavlinkTransmissionState getTransmissionState() {
+    return transmissionState;
+  }
+
+  // Called only while holding the sender lock; readers receive an immutable snapshot.
+  private void updateTransmission(String state, String reason) {
+    transmissionStatus = state;
+    if (reason != null && !reason.isBlank()) {
+      transmissionReason = reason;
+    }
+    transmissionState.update(new MavlinkTransmissionState.Snapshot(
+        sequenceId.toString(), commandSet.operation().name(), state, transmissionMessageIndex,
+        messages.size(), lastMissionSequence, missionItemTotal, sendAttempts, retryCount, maxRetries,
+        totalPacketRetries, missionRestartCount, MAX_MISSION_RESTARTS, acknowledgementTimeoutMillis,
+        transmissionStartedAt, System.currentTimeMillis(), lastSentAt, lastResponseAt, nextRetryAt,
+        messageName(lastSentMessage), lastReceivedMessage == null ? null : lastReceivedMessage.getClass().getSimpleName(),
+        transmissionReason));
   }
 
   private MavlinkMessage messageAt(int index) {

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandler.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandler.java
@@ -217,6 +217,12 @@ public class MavlinkMissionAcknowledgementHandler
       return Acknowledgement.notRelated();
     }
 
+    if (packet.getType() == MissionAckPacket.MAV_MISSION_INVALID_SEQUENCE && missionItemOffset > 0) {
+      expectedSequence = 0;
+      return Acknowledgement.restart(missionItemOffset - 1,
+          "Mission upload rejected with INVALID_SEQUENCE");
+    }
+
     if (!packet.isAccepted()) {
       return Acknowledgement.fail(
           "Mission upload failed with result "

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandler.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandler.java
@@ -178,6 +178,12 @@ public class MavlinkMissionAcknowledgementHandler
               + Math.max(0, missionItemCount - 1));
     }
 
+    // A delayed request from an earlier upload must not abort a fresh count handshake.
+    // NOT_RELATED leaves the count retry timer and budget untouched.
+    if (expectedSequence == 0 && sequence != 0) {
+      return Acknowledgement.notRelated();
+    }
+
     if (sequence == expectedSequence) {
       expectedSequence++;
       return sendMissionItem(sequence);

--- a/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkTransmissionState.java
+++ b/src/main/java/io/mapsmessaging/state/mavlink/sender/MavlinkTransmissionState.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.mapsmessaging.state.mavlink.sender;
+
+import lombok.Getter;
+
+/** A small retained snapshot; never retains the sender or its mission payload. */
+@Getter
+public final class MavlinkTransmissionState {
+  private volatile Snapshot snapshot;
+
+  void update(Snapshot value) {
+    snapshot = value;
+  }
+
+  public record Snapshot(
+      String transferId, String operation, String state, int messageIndex, int messageTotal,
+      Integer missionSequence, int missionItemTotal, long sendAttempts, int packetRetries,
+      int packetRetryLimit, long totalPacketRetries, int missionRestarts, int missionRestartLimit,
+      long acknowledgementTimeoutMillis, Long startedAt, long updatedAt, Long lastSentAt,
+      Long lastResponseAt, Long nextRetryAt, String lastMessage, String lastResponse, String reason) {}
+}

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderMissionProtocolTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderMissionProtocolTest.java
@@ -71,21 +71,39 @@ class MavlinkEventListSenderMissionProtocolTest {
   }
 
   @Test
-  void missionProtocolFailsWhenVehicleSkipsFirstItemRequest() throws Exception {
-    Fixture fixture = fixture(3);
+  void stale_sequence_six_preserves_count_retry_and_can_recover() throws Exception {
+    Fixture fixture = fixture(7);
+    try (MavlinkEventListSender sender = fixture.newSender()) {
+      sender.start();
+      sender.onMavlinkMessage(fixture.requestInt(6));
+      assertTrue(fixture.results.isEmpty());
+      sender.timeout();
+      assertEquals(1, sender.getRetryCount());
+      sender.onMavlinkMessage(fixture.requestInt(6));
+      assertEquals(1, sender.getRetryCount());
+      verify(fixture.sender, times(2)).send(fixture.missionCountMessage);
+      verify(fixture.sender, never()).send(fixture.itemMessages.get(6));
+      for (int sequence = 0; sequence < 7; sequence++) {
+        sender.onMavlinkMessage(fixture.requestInt(sequence));
+      }
+      sender.onMavlinkMessage(fixture.acceptedMissionAck());
+      assertEquals(1, fixture.results.size());
+      assertEquals(SUCCESS, fixture.results.get(0).status());
+    }
+  }
 
-    MavlinkEventListSender sender = fixture.newSender();
-    sender.start();
-    sender.onMavlinkMessage(fixture.requestInt(1));
-
-    verify(fixture.sender).send(fixture.missionCountMessage);
-    verify(fixture.sender, never()).send(fixture.itemMessages.get(0));
-    verify(fixture.sender, never()).send(fixture.itemMessages.get(1));
-    verify(fixture.sender, never()).send(fixture.itemMessages.get(2));
-
-    assertEquals(1, fixture.results.size());
-    assertEquals(FAILED, fixture.results.get(0).status());
-    assertEquals("Mission requested sequence 1 but expected 0", fixture.results.get(0).reason());
+  @Test
+  void repeated_stale_requests_exhaust_count_retries_without_aborting_task() {
+    Fixture fixture = fixture(7);
+    try (MavlinkEventListSender sender = fixture.newSender(1)) {
+      sender.start();
+      sender.onMavlinkMessage(fixture.requestInt(6));
+      sender.timeout();
+      sender.onMavlinkMessage(fixture.requestInt(6));
+      sender.timeout();
+      assertEquals(1, fixture.results.size());
+      assertEquals(MavlinkSendResult.Status.TIMEOUT, fixture.results.get(0).status());
+    }
   }
 
   @Test
@@ -279,6 +297,8 @@ class MavlinkEventListSenderMissionProtocolTest {
       verify(fixture.sender, never()).send(fixture.itemMessages.get(1));
       sender.timeout();
       verify(fixture.sender, times(2)).send(fixture.missionCountMessage);
+      sender.onMavlinkMessage(fixture.requestInt(1));
+      assertTrue(fixture.results.isEmpty());
       sender.onMavlinkMessage(fixture.requestInt(0));
       sender.onMavlinkMessage(fixture.requestInt(1));
       sender.onMavlinkMessage(fixture.acceptedMissionAck());

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderMissionProtocolTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderMissionProtocolTest.java
@@ -253,7 +253,7 @@ class MavlinkEventListSenderMissionProtocolTest {
 
     MavlinkEventListSender sender = fixture.newSender();
     sender.start();
-    sender.onMavlinkMessage(fixture.rejectedMissionAck("INVALID_SEQUENCE"));
+    sender.onMavlinkMessage(fixture.rejectedMissionAck("UNSUPPORTED"));
 
     verify(fixture.sender).send(fixture.missionCountMessage);
     verify(fixture.sender, never()).send(fixture.itemMessages.get(0));
@@ -262,7 +262,81 @@ class MavlinkEventListSenderMissionProtocolTest {
 
     assertEquals(1, fixture.results.size());
     assertEquals(FAILED, fixture.results.get(0).status());
-    assertEquals("Mission upload failed with result INVALID_SEQUENCE", fixture.results.get(0).reason());
+    assertEquals("Mission upload failed with result UNSUPPORTED", fixture.results.get(0).reason());
+  }
+
+  @Test
+  void invalid_sequence_restarts_upload_and_requires_all_items_again() throws Exception {
+    Fixture fixture = fixture(2);
+    try (MavlinkEventListSender sender = fixture.newSender()) {
+      sender.start();
+      sender.onMavlinkMessage(fixture.requestInt(0));
+      sender.onMavlinkMessage(fixture.rejectedMissionAck("INVALID_SEQUENCE"));
+      assertTrue(fixture.results.isEmpty());
+      // Packets arriving during backoff cannot advance the replacement transfer.
+      sender.onMavlinkMessage(fixture.requestInt(1));
+      sender.onMavlinkMessage(fixture.acceptedMissionAck());
+      verify(fixture.sender, never()).send(fixture.itemMessages.get(1));
+      sender.timeout();
+      verify(fixture.sender, times(2)).send(fixture.missionCountMessage);
+      sender.onMavlinkMessage(fixture.requestInt(0));
+      sender.onMavlinkMessage(fixture.requestInt(1));
+      sender.onMavlinkMessage(fixture.acceptedMissionAck());
+      assertEquals(1, fixture.results.size());
+      assertEquals(SUCCESS, fixture.results.get(0).status());
+      verify(fixture.sender, times(2)).send(fixture.itemMessages.get(0));
+    }
+  }
+
+  @Test
+  void invalid_sequence_exhaustion_reports_timeout_for_task_resend() throws Exception {
+    Fixture fixture = fixture(1);
+    try (MavlinkEventListSender sender = fixture.newSender()) {
+      sender.start();
+      for (int attempt = 0; attempt < 3; attempt++) {
+        sender.onMavlinkMessage(fixture.rejectedMissionAck("INVALID_SEQUENCE"));
+        sender.timeout();
+      }
+      verify(fixture.sender, times(3)).send(fixture.missionCountMessage);
+      assertEquals(1, fixture.results.size());
+      assertEquals(MavlinkSendResult.Status.TIMEOUT, fixture.results.get(0).status());
+      sender.onMavlinkMessage(fixture.acceptedMissionAck());
+      assertEquals(1, fixture.results.size());
+    }
+  }
+
+  @Test
+  void cancel_during_restart_backoff_prevents_retransmission() throws Exception {
+    Fixture fixture = fixture(1);
+    try (MavlinkEventListSender sender = fixture.newSender()) {
+      sender.start();
+      sender.onMavlinkMessage(fixture.rejectedMissionAck("INVALID_SEQUENCE"));
+      sender.cancel();
+      sender.timeout();
+      verify(fixture.sender).send(fixture.missionCountMessage);
+      assertEquals(1, fixture.results.size());
+      assertEquals(MavlinkSendResult.Status.CANCELLED, fixture.results.get(0).status());
+    }
+  }
+
+  @Test
+  void scheduled_restart_sends_count_without_manual_timeout() throws Exception {
+    Fixture fixture = fixture(1);
+    java.util.concurrent.CountDownLatch restarted = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.atomic.AtomicInteger counts = new java.util.concurrent.atomic.AtomicInteger();
+    org.mockito.Mockito.doAnswer(invocation -> {
+      if (counts.incrementAndGet() == 2) {
+        restarted.countDown();
+      }
+      return null;
+    }).when(fixture.sender).send(fixture.missionCountMessage);
+    try (MavlinkEventListSender sender = new MavlinkEventListSender(
+        commandSet(fixture.messages), fixture.sender, fixture.acknowledgementHandler,
+        fixture.results::add, 3, 100)) {
+      sender.start();
+      sender.onMavlinkMessage(fixture.rejectedMissionAck("INVALID_SEQUENCE"));
+      assertTrue(restarted.await(2, java.util.concurrent.TimeUnit.SECONDS));
+    }
   }
 
   private Fixture fixture(int itemCount) {
@@ -345,6 +419,7 @@ class MavlinkEventListSenderMissionProtocolTest {
       when(packet.isValid()).thenReturn(true);
       when(packet.isAccepted()).thenReturn(false);
       when(packet.getTypeName()).thenReturn(resultName);
+      when(packet.getType()).thenReturn("INVALID_SEQUENCE".equals(resultName) ? 13 : 3);
       when(packet.getTargetSystem()).thenReturn(LOCAL_SYSTEM_ID);
       when(packet.getTargetComponent()).thenReturn(LOCAL_COMPONENT_ID);
       when(packet.isMissionTypePresent()).thenReturn(true);

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkEventListSenderTest.java
@@ -58,6 +58,37 @@ import static org.mockito.Mockito.when;
 class MavlinkEventListSenderTest {
 
   @Test
+  void transmission_snapshot_tracks_retries_and_retains_terminal_state() {
+    Fixture fixture = fixture();
+    fixture.messages.add(fixture.message(true));
+    MavlinkEventListSender sender = fixture.newSender();
+    io.mapsmessaging.state.drone.drone.DroneTwin drone =
+        new io.mapsmessaging.state.drone.drone.DroneTwin("test");
+    assertTrue(drone.registerMavlinkSender(sender));
+    try {
+      sender.start();
+      var first = drone.getMissionTransmission().getSnapshot();
+      assertEquals("WAITING_RESPONSE", first.state());
+      assertEquals(1L, first.sendAttempts());
+      sender.timeout();
+      var retry = drone.getMissionTransmission().getSnapshot();
+      assertEquals(1L, retry.totalPacketRetries());
+      assertEquals(2L, retry.sendAttempts());
+      assertEquals(1L, first.sendAttempts());
+      sender.cancel();
+      assertTrue(drone.removeMavlinkSender(sender));
+      assertEquals("CANCELLED", drone.getMissionTransmission().getSnapshot().state());
+      assertNull(drone.getMissionTransmission().getSnapshot().nextRetryAt());
+      String json = io.mapsmessaging.state.StateJsonHelper.createGson().toJson(drone);
+      assertTrue(json.contains("\"missionTransmission\""));
+      assertTrue(json.contains("\"totalPacketRetries\":1"));
+    } finally {
+      sender.close();
+    }
+  }
+
+
+  @Test
   void constructorRejectsNullCommandSet() {
     assertThrows(NullPointerException.class, () -> new MavlinkEventListSender(null, mock(MavlinkEventSender.class), mock(MavlinkAcknowledgementHandler.class), result -> {}));
   }

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandlerTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandlerTest.java
@@ -122,14 +122,14 @@ class MavlinkMissionAcknowledgementHandlerTest {
   }
 
   @Test
-  void requestSkippingSequenceFails() {
+  void nonzero_request_before_first_item_is_ignored() {
     List<MavlinkMessage> messages = messages(4);
     MavlinkMissionAcknowledgementHandler handler = new MavlinkMissionAcknowledgementHandler(messages, 3);
 
     Acknowledgement acknowledgement = handler.acknowledge(messages.get(0), requestInt(1));
 
-    assertEquals(Action.FAIL, acknowledgement.action());
-    assertEquals("Mission requested sequence 1 but expected 0", acknowledgement.reason());
+    assertEquals(Action.NOT_RELATED, acknowledgement.action());
+    assertEquals(Action.SEND_INDEX, handler.acknowledge(messages.get(0), requestInt(0)).action());
   }
 
   @Test

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandlerTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/MavlinkMissionAcknowledgementHandlerTest.java
@@ -277,15 +277,16 @@ class MavlinkMissionAcknowledgementHandlerTest {
   }
 
   @Test
-  void rejectedMissionAckFails() {
+  void invalid_sequence_restarts_from_count() {
     List<MavlinkMessage> messages = messages(4);
     MavlinkMissionAcknowledgementHandler handler = new MavlinkMissionAcknowledgementHandler(messages, 3);
     MissionAckPacket missionAckPacket = missionAck(false, "INVALID_SEQUENCE", 13, 0, 0, false, 0);
 
     Acknowledgement acknowledgement = handler.acknowledge(messages.get(0), missionAckPacket);
 
-    assertEquals(Action.FAIL, acknowledgement.action());
-    assertEquals("Mission upload failed with result INVALID_SEQUENCE", acknowledgement.reason());
+    assertEquals(Action.RESTART, acknowledgement.action());
+    assertEquals(0, acknowledgement.index());
+    assertEquals(Action.SEND_INDEX, handler.acknowledge(messages.get(0), requestInt(0)).action());
   }
 
   @Test

--- a/src/test/java/io/mapsmessaging/state/mavlink/sender/UxvNavigationSenderTest.java
+++ b/src/test/java/io/mapsmessaging/state/mavlink/sender/UxvNavigationSenderTest.java
@@ -289,7 +289,7 @@ class UxvNavigationSenderTest {
             });
 
     missionSender.start();
-    missionSender.onMavlinkMessage(rejectedMissionAck("INVALID_SEQUENCE"));
+    missionSender.onMavlinkMessage(rejectedMissionAck("UNSUPPORTED"));
 
     MavlinkMessage startMission =
         plan.postMissionUploadPhase().getFirst().messages().getFirst();
@@ -301,7 +301,7 @@ class UxvNavigationSenderTest {
     assertEquals(1, missionResults.size());
     assertEquals(FAILED, missionResults.getFirst().status());
     assertEquals(
-        "Mission upload failed with result INVALID_SEQUENCE",
+        "Mission upload failed with result UNSUPPORTED",
         missionResults.getFirst().reason());
     assertNull(startSender.get());
   }


### PR DESCRIPTION
## Problem
An INVALID_SEQUENCE mission acknowledgement immediately fails initial STANAG dispatch, aborting a task that could recover by uploading again.

## Changes
- Reset mission sequence tracking and restart from MISSION_COUNT, without clearing the onboard plan.
- Allow two restart attempts with one/two acknowledgement intervals of backoff (2 s/4 s by default).
- Ignore inbound responses during backoff; cancel pending restart on cancel/close and guard stale timer callbacks.
- Return TIMEOUT on restart exhaustion to use the existing STANAG resend path. Other rejection types remain FAILED.
- Add recovery, exhaustion, cancellation and scheduled restart regression tests; retain unsupported-rejection navigation coverage.

## Validation
`git diff --check` passed.
Attempted Java 21 Maven: `mvn -o -Dtest=MavlinkMissionAcknowledgementHandlerTest,MavlinkEventListSenderMissionProtocolTest,MavlinkEventListSenderConcurrencyTest test`.
Blocked before compilation by uncached AWS SDK 2.46.15 and Jersey 4.0.2 BOMs. Network access unavailable. Tests have NOT run; draft pending CI and marine profile validation.

## Scope and remaining risks
No connectivity gating or new task expiry policy. ANY_LOCAL_ID recipient wiring and repeated-request no-progress limits remain follow-ups under MSG-227. MAVLink has no attempt ID; late packets after backoff cannot be reliably attributed to an older upload. No STANAG dependency/API changes required; existing timeout handling retains initial task for resend.

Refs: MSG-227

Transmission diagnostics (MSG-227): added Twin sender snapshots and adapter task retry telemetry for stanag_web_viewer PR #26. Snapshots include current message/mission sequence, send attempts, packet retry budget and cumulative timeout retries, mission restarts, timestamps and terminal reason. Latest sender snapshot is retained without retaining its mission payload. Adapter tracks task ID, retry budget, attempt, backoff and deadline. Uses the existing Twin publication cadence; during telemetry silence the UI shows the last received snapshot and its timestamp. New server snapshot/serialization and adapter retry-budget tests added; CI pending. Adapter validation on MSG-258 now selects server MSG-227 to compile against the additive Twin API.