### PR TITLE
fix(mavlink): validate outbound sender identity

### DIFF
--- a/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/MavlinkConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/dto/rest/config/protocol/impl/MavlinkConfigDTO.java
@@ -36,7 +36,7 @@ public class MavlinkConfigDTO extends ProtocolConfigDTO {
           "Local MAVLink component id used by this protocol instance when it originates MAVLink frames, such as heartbeats or outbound commands. "
               + "If null, this MAVLink interface is listen-only and does not originate MAVLink traffic.",
       example = "190",
-      minimum = "0",
+      minimum = "1",
       maximum = "255",
       requiredMode = Schema.RequiredMode.NOT_REQUIRED,
       nullable = true
@@ -44,7 +44,7 @@ public class MavlinkConfigDTO extends ProtocolConfigDTO {
   protected Integer componentId;
 
   public boolean hasLocalMavlinkIdentity() {
-    return systemId != null && componentId != null;
+    return systemId != null && systemId >= 1 && componentId != null && componentId >= 1;
   }
 
   @Schema(

--- a/src/test/java/io/mapsmessaging/dto/rest/config/protocol/impl/MavlinkConfigDTOTest.java
+++ b/src/test/java/io/mapsmessaging/dto/rest/config/protocol/impl/MavlinkConfigDTOTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright [ 2020 - 2024 ] Matthew Buckton
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause
+ */
+
+package io.mapsmessaging.dto.rest.config.protocol.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MavlinkConfigDTOTest {
+
+  @Test
+  void listenOnlyConfigurationHasNoLocalIdentity() {
+    MavlinkConfigDTO config = new MavlinkConfigDTO();
+
+    assertFalse(config.hasLocalMavlinkIdentity());
+  }
+
+  @Test
+  void zeroComponentIdCannotEnableOutboundMavlink() {
+    MavlinkConfigDTO config = new MavlinkConfigDTO();
+    config.setSystemId(255);
+    config.setComponentId(0);
+
+    assertFalse(config.hasLocalMavlinkIdentity());
+  }
+
+  @Test
+  void validSystemAndComponentIdsEnableOutboundMavlink() {
+    MavlinkConfigDTO config = new MavlinkConfigDTO();
+    config.setSystemId(255);
+    config.setComponentId(190);
+
+    assertTrue(config.hasLocalMavlinkIdentity());
+  }
+}


### PR DESCRIPTION
## Summary

- Treat missing or zero MAVLink system/component IDs as listen-only.
- Add regression coverage for outbound identity eligibility.

## Validation

- Server MAVLink configuration tests.
- Full server Maven validation via CI.

Refs: MSG-227