### PR TITLE
feat(cot): add namespace-aware classification mapping

### DIFF
--- a/src/main/java/io/mapsmessaging/state/config/CotAffiliation.java
+++ b/src/main/java/io/mapsmessaging/state/config/CotAffiliation.java
@@ -1,0 +1,30 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.mapsmessaging.state.config;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Cursor on Target affiliation policy for a configured source namespace.")
+public enum CotAffiliation {
+  SOURCE,
+  FRIENDLY,
+  HOSTILE,
+  NEUTRAL,
+  UNKNOWN
+}

--- a/src/main/java/io/mapsmessaging/state/config/CotConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/state/config/CotConfigDTO.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.mapsmessaging.state.config;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Cursor on Target mapping and CoT-only defaults for a source namespace.")
+public class CotConfigDTO {
+
+  @Schema(
+      description = "Source namespace or MQTT-style namespace filter. '+' matches one level and '#' matches remaining levels.",
+      example = "4817/catl/maps/+/+/+")
+  private String namespacePath;
+
+  @Schema(
+      description = "Affiliation applied to CoT events. SOURCE preserves affiliation supplied by the source event when available.",
+      defaultValue = "SOURCE")
+  private CotAffiliation affiliation = CotAffiliation.SOURCE;
+
+  @Schema(description = "CoT how value.", defaultValue = "h-g-i-g-o")
+  private String how = "h-g-i-g-o";
+
+  @Schema(description = "CoT stale interval in milliseconds.", defaultValue = "30000", minimum = "1")
+  private long staleTimeoutMillis = 30_000L;
+
+  @Schema(description = "Optional prefix prepended to generated CoT UIDs.", nullable = true)
+  private String uidPrefix;
+
+  @Schema(description = "Default CoT circular error in metres when source accuracy is unavailable.", defaultValue = "10.0", minimum = "0")
+  private Double defaultCircularErrorMeters = 10.0d;
+
+  @Schema(description = "Default CoT linear error in metres when source accuracy is unavailable.", defaultValue = "15.0", minimum = "0")
+  private Double defaultLinearErrorMeters = 15.0d;
+
+  @Schema(description = "CoT precision-location altitude source.", defaultValue = "GPS")
+  private String altitudeSource = "GPS";
+}

--- a/src/main/java/io/mapsmessaging/state/config/CotConfigSupport.java
+++ b/src/main/java/io/mapsmessaging/state/config/CotConfigSupport.java
@@ -1,0 +1,119 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.mapsmessaging.state.config;
+
+import io.mapsmessaging.configuration.ConfigurationProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public final class CotConfigSupport {
+
+  private CotConfigSupport() {}
+
+  public static List<CotConfigDTO> parse(Object value) {
+    List<CotConfigDTO> configs = new ArrayList<>();
+    if (value instanceof ConfigurationProperties properties) {
+      configs.add(parseEntry(properties));
+    } else if (value instanceof List<?> entries) {
+      for (Object entry : entries) {
+        if (entry instanceof ConfigurationProperties properties) {
+          configs.add(parseEntry(properties));
+        }
+      }
+    }
+    return configs;
+  }
+
+  public static List<ConfigurationProperties> toConfigurationProperties(List<CotConfigDTO> configs) {
+    List<ConfigurationProperties> values = new ArrayList<>();
+    if (configs == null) {
+      return values;
+    }
+
+    for (CotConfigDTO config : configs) {
+      if (config == null) {
+        continue;
+      }
+      ConfigurationProperties properties = new ConfigurationProperties();
+      properties.put("namespacePath", config.getNamespacePath());
+      properties.put("affiliation", config.getAffiliation().name());
+      properties.put("how", config.getHow());
+      properties.put("staleTimeoutMillis", config.getStaleTimeoutMillis());
+      if (config.getUidPrefix() != null) {
+        properties.put("uidPrefix", config.getUidPrefix());
+      }
+      if (config.getDefaultCircularErrorMeters() != null) {
+        properties.put("defaultCircularErrorMeters", config.getDefaultCircularErrorMeters());
+      }
+      if (config.getDefaultLinearErrorMeters() != null) {
+        properties.put("defaultLinearErrorMeters", config.getDefaultLinearErrorMeters());
+      }
+      properties.put("altitudeSource", config.getAltitudeSource());
+      values.add(properties);
+    }
+    return values;
+  }
+
+  private static CotConfigDTO parseEntry(ConfigurationProperties properties) {
+    CotConfigDTO config = new CotConfigDTO();
+    config.setNamespacePath(properties.getProperty("namespacePath", null));
+    config.setAffiliation(parseAffiliation(properties.getProperty("affiliation", null), config.getAffiliation()));
+    config.setHow(properties.getProperty("how", config.getHow()));
+    config.setStaleTimeoutMillis(properties.getLongProperty("staleTimeoutMillis", config.getStaleTimeoutMillis()));
+    config.setUidPrefix(properties.getProperty("uidPrefix", null));
+    if (properties.containsKey("defaultCircularErrorMeters")) {
+      config.setDefaultCircularErrorMeters(properties.getDoubleProperty("defaultCircularErrorMeters", config.getDefaultCircularErrorMeters()));
+    }
+    if (properties.containsKey("defaultLinearErrorMeters")) {
+      config.setDefaultLinearErrorMeters(properties.getDoubleProperty("defaultLinearErrorMeters", config.getDefaultLinearErrorMeters()));
+    }
+    config.setAltitudeSource(properties.getProperty("altitudeSource", config.getAltitudeSource()));
+    validate(config);
+    return config;
+  }
+
+  private static CotAffiliation parseAffiliation(String value, CotAffiliation defaultValue) {
+    if (value == null || value.isBlank()) {
+      return defaultValue;
+    }
+    String normalised = value.trim().toUpperCase(Locale.ROOT);
+    if ("ENEMY".equals(normalised)) {
+      return CotAffiliation.HOSTILE;
+    }
+    return CotAffiliation.valueOf(normalised);
+  }
+
+  private static void validate(CotConfigDTO config) {
+    if (config.getNamespacePath() == null || config.getNamespacePath().isBlank()) {
+      throw new IllegalArgumentException("CoT namespacePath must not be blank");
+    }
+    if (config.getStaleTimeoutMillis() < 1) {
+      throw new IllegalArgumentException("CoT staleTimeoutMillis must be positive");
+    }
+    validateError(config.getDefaultCircularErrorMeters(), "defaultCircularErrorMeters");
+    validateError(config.getDefaultLinearErrorMeters(), "defaultLinearErrorMeters");
+  }
+
+  private static void validateError(Double value, String name) {
+    if (value != null && (!Double.isFinite(value) || value < 0.0d)) {
+      throw new IllegalArgumentException("CoT " + name + " must be finite and non-negative");
+    }
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/config/CotConfigSupport.java
+++ b/src/main/java/io/mapsmessaging/state/config/CotConfigSupport.java
@@ -53,7 +53,9 @@ public final class CotConfigSupport {
       }
       ConfigurationProperties properties = new ConfigurationProperties();
       properties.put("namespacePath", config.getNamespacePath());
-      properties.put("affiliation", config.getAffiliation().name());
+      CotAffiliation affiliation =
+          config.getAffiliation() == null ? CotAffiliation.SOURCE : config.getAffiliation();
+      properties.put("affiliation", affiliation.name());
       properties.put("how", config.getHow());
       properties.put("staleTimeoutMillis", config.getStaleTimeoutMillis());
       if (config.getUidPrefix() != null) {

--- a/src/main/java/io/mapsmessaging/state/config/CotConfigSupport.java
+++ b/src/main/java/io/mapsmessaging/state/config/CotConfigSupport.java
@@ -95,11 +95,7 @@ public final class CotConfigSupport {
     if (value == null || value.isBlank()) {
       return defaultValue;
     }
-    String normalised = value.trim().toUpperCase(Locale.ROOT);
-    if ("ENEMY".equals(normalised)) {
-      return CotAffiliation.HOSTILE;
-    }
-    return CotAffiliation.valueOf(normalised);
+    return CotAffiliation.valueOf(value.trim().toUpperCase(Locale.ROOT));
   }
 
   private static void validate(CotConfigDTO config) {

--- a/src/main/java/io/mapsmessaging/state/config/TwinManagerConfigDTO.java
+++ b/src/main/java/io/mapsmessaging/state/config/TwinManagerConfigDTO.java
@@ -38,6 +38,9 @@ import java.util.Map;
 @Schema(description = "State/Twin Manager Configuration DTO")
 public class TwinManagerConfigDTO extends BaseManagerConfigDTO {
 
+  private static final String COT_ADAPTER_CONFIG_KEY = "cot";
+  private static final String COT_MAPPINGS_CONFIG_KEY = "mappings";
+
   @Schema(
       description = "Time in milliseconds after which a twin is considered disconnected if no updates are received.",
       example = "5000",
@@ -123,6 +126,28 @@ public class TwinManagerConfigDTO extends BaseManagerConfigDTO {
 
   public TwinManagerConfigDTO() {
     super("TwinManagerConfigDTO");
+  }
+
+  @Schema(
+      description = "CoT source namespace mappings and CoT-only defaults stored under stateAdapters.cot.mappings."
+  )
+  public List<CotConfigDTO> getCot() {
+    ConfigurationProperties cotConfig = adapterConfig.get(COT_ADAPTER_CONFIG_KEY);
+    if (cotConfig == null) {
+      return List.of();
+    }
+    return CotConfigSupport.parse(cotConfig.get(COT_MAPPINGS_CONFIG_KEY));
+  }
+
+  public void setCot(List<CotConfigDTO> cot) {
+    if (cot == null || cot.isEmpty()) {
+      adapterConfig.remove(COT_ADAPTER_CONFIG_KEY);
+      return;
+    }
+
+    ConfigurationProperties cotConfig = new ConfigurationProperties();
+    cotConfig.put(COT_MAPPINGS_CONFIG_KEY, CotConfigSupport.toConfigurationProperties(cot));
+    adapterConfig.put(COT_ADAPTER_CONFIG_KEY, cotConfig);
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/state/config/VehicleClass.java
+++ b/src/main/java/io/mapsmessaging/state/config/VehicleClass.java
@@ -46,8 +46,8 @@ public enum VehicleClass {
       case UAV -> "SymbolSetEnum_AIR";
       case USV -> "SymbolSetEnum_SEA_SURFACE";
       case UGV -> "SymbolSetEnum_LAND_UNIT";
-      case UUV -> "SymbolSetEnum_SUBSURFACE";
-      case GCS -> "SymbolSetEnum_CONTROL";
+      case UUV -> "SymbolSetEnum_SEA_SUBSURFACE";
+      case GCS -> "SymbolSetEnum_CONTROL_MEASURE";
       case UNKNOWN -> "SymbolSetEnum_UNKNOWN";
     };
   }

--- a/src/main/java/io/mapsmessaging/state/drone/core/EntityTwin.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/EntityTwin.java
@@ -147,6 +147,12 @@ public abstract class EntityTwin {
   private TwinLifecycleStatus lifecycleStatus = TwinLifecycleStatus.ACTIVE;
 
   @Schema(
+      description = "Retention policy controlling scheduled removal after the global retention timeout.",
+      defaultValue = "DEFAULT",
+      nullable = false)
+  private TwinRetentionPolicy retentionPolicy = TwinRetentionPolicy.DEFAULT;
+
+  @Schema(
       description = "Relationship edges owned by this twin.",
       nullable = false
   )

--- a/src/main/java/io/mapsmessaging/state/drone/core/TwinManager.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/TwinManager.java
@@ -293,6 +293,9 @@ public class TwinManager {
     List<String> expiredIds = new ArrayList<>();
 
     for (EntityTwin twin : twins.values()) {
+      if (twin.getRetentionPolicy() == TwinRetentionPolicy.PERSISTENT) {
+        continue;
+      }
       long ageMillis = ageMillis(effectiveNow, twin.getLastSeenAt());
       if (ageMillis >= retentionTimeoutMillis) {
         expiredIds.add(twin.getTwinId());

--- a/src/main/java/io/mapsmessaging/state/drone/core/TwinRetentionPolicy.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/TwinRetentionPolicy.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.mapsmessaging.state.drone.core;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Retention policy controlling whether a Twin is removed by the global retention timeout.")
+public enum TwinRetentionPolicy {
+  DEFAULT,
+  PERSISTENT
+}

--- a/src/main/java/io/mapsmessaging/state/drone/core/TwinType.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/TwinType.java
@@ -21,8 +21,9 @@ package io.mapsmessaging.state.drone.core;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "Type of twin (DRONE, GROUND_CONTROL, etc).")
+@Schema(description = "Type of twin (DRONE, CONTACT, GROUND_CONTROL, etc).")
 public enum TwinType {
   DRONE,
+  CONTACT,
   GROUND_CONTROL
 }

--- a/src/main/java/io/mapsmessaging/state/drone/core/TwinUpdateContext.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/TwinUpdateContext.java
@@ -61,4 +61,27 @@ public class TwinUpdateContext {
   private String responseTopic;
 
   private String uniqueOutboundIdentifier;
+
+  public TwinUpdateContext(
+      String updateSource,
+      String sourceInstanceId,
+      Instant eventTime,
+      Instant receivedTime,
+      Long sequenceNumber,
+      String reason,
+      boolean fullSnapshot,
+      String responseTopic,
+      String uniqueOutboundIdentifier) {
+    this(
+        updateSource,
+        sourceInstanceId,
+        null,
+        eventTime,
+        receivedTime,
+        sequenceNumber,
+        reason,
+        fullSnapshot,
+        responseTopic,
+        uniqueOutboundIdentifier);
+  }
 }

--- a/src/main/java/io/mapsmessaging/state/drone/core/TwinUpdateContext.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/TwinUpdateContext.java
@@ -40,6 +40,9 @@ public class TwinUpdateContext {
   /** Optional unique source instance/node id. */
   private String sourceInstanceId;
 
+  /** Optional source namespace or topic used to route context-aware adapters. */
+  private String sourceNamespace;
+
   /** Event timestamp from upstream payload if present. */
   private Instant eventTime;
 

--- a/src/main/java/io/mapsmessaging/state/drone/tak/CotConfigResolver.java
+++ b/src/main/java/io/mapsmessaging/state/drone/tak/CotConfigResolver.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.mapsmessaging.state.drone.tak;
+
+import io.mapsmessaging.state.config.CotConfigDTO;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class CotConfigResolver {
+
+  private final List<CotConfigDTO> configs;
+
+  public CotConfigResolver(List<CotConfigDTO> configs) {
+    this.configs = configs == null ? List.of() : List.copyOf(configs);
+  }
+
+  public CotConfigDTO resolve(String namespace) {
+    if (namespace == null || namespace.isBlank()) {
+      return null;
+    }
+
+    CotConfigDTO best = null;
+    int bestScore = Integer.MIN_VALUE;
+    for (CotConfigDTO config : configs) {
+      if (config == null || !matches(config.getNamespacePath(), namespace)) {
+        continue;
+      }
+      int score = specificity(config.getNamespacePath());
+      if (score > bestScore) {
+        best = config;
+        bestScore = score;
+      }
+    }
+    return best;
+  }
+
+  static boolean matches(String pattern, String namespace) {
+    if (pattern == null || pattern.isBlank() || namespace == null || namespace.isBlank()) {
+      return false;
+    }
+
+    List<String> patternLevels = levels(pattern);
+    List<String> namespaceLevels = levels(namespace);
+    int namespaceIndex = 0;
+
+    for (int patternIndex = 0; patternIndex < patternLevels.size(); patternIndex++) {
+      String patternLevel = patternLevels.get(patternIndex);
+      if ("#".equals(patternLevel)) {
+        return patternIndex == patternLevels.size() - 1;
+      }
+      if (namespaceIndex >= namespaceLevels.size()) {
+        return false;
+      }
+      if (!"+".equals(patternLevel) && !patternLevel.equals(namespaceLevels.get(namespaceIndex))) {
+        return false;
+      }
+      namespaceIndex++;
+    }
+    return namespaceIndex == namespaceLevels.size();
+  }
+
+  private static int specificity(String pattern) {
+    int score = 0;
+    for (String level : levels(pattern)) {
+      if ("#".equals(level)) {
+        score += 1;
+      } else if ("+".equals(level)) {
+        score += 10;
+      } else {
+        score += 100;
+      }
+    }
+    return score;
+  }
+
+  private static List<String> levels(String path) {
+    String[] rawLevels = path.trim().split("/", -1);
+    List<String> result = new ArrayList<>(rawLevels.length);
+    for (String level : rawLevels) {
+      if (!level.isEmpty()) {
+        result.add(level);
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/drone/tak/CotEventPolicy.java
+++ b/src/main/java/io/mapsmessaging/state/drone/tak/CotEventPolicy.java
@@ -153,7 +153,7 @@ final class CotEventPolicy {
       case "ASSUMED_FRIEND" -> "a";
       case "NEUTRAL" -> "n";
       case "SUSPECT" -> "s";
-      case "HOSTILE", "ENEMY" -> "h";
+      case "HOSTILE" -> "h";
       case "PENDING" -> "p";
       default -> "u";
     };

--- a/src/main/java/io/mapsmessaging/state/drone/tak/CotEventPolicy.java
+++ b/src/main/java/io/mapsmessaging/state/drone/tak/CotEventPolicy.java
@@ -1,0 +1,216 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.mapsmessaging.state.drone.tak;
+
+import io.mapsmessaging.state.config.CotAffiliation;
+import io.mapsmessaging.state.config.CotConfigDTO;
+import io.mapsmessaging.state.config.VehicleClass;
+import io.mapsmessaging.state.drone.core.EntityTwin;
+import io.mapsmessaging.state.drone.core.TwinType;
+import io.mapsmessaging.state.drone.core.TwinUpdateContext;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import io.mapsmessaging.state.drone.model.FixInfo;
+import io.mapsmessaging.state.drone.tak.model.TakDetail;
+import io.mapsmessaging.state.drone.tak.model.TakEvent;
+import io.mapsmessaging.state.drone.tak.model.TakPoint;
+import io.mapsmessaging.state.drone.tak.model.TakPrecisionLocation;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Map;
+
+final class CotEventPolicy {
+
+  private static final long DEFAULT_STALE_TIMEOUT_MILLIS = 30_000L;
+  private static final double DEFAULT_CE_METERS = 10.0d;
+  private static final double DEFAULT_LE_METERS = 15.0d;
+  private static final String DEFAULT_HOW = "h-g-i-g-o";
+  private static final String DEFAULT_ALTITUDE_SOURCE = "GPS";
+
+  void apply(TakEvent event, EntityTwin twin, TwinUpdateContext context, CotConfigDTO config) {
+    apply(event, twin, context, config, false);
+  }
+
+  void applyRemoval(TakEvent event, EntityTwin twin, TwinUpdateContext context, CotConfigDTO config) {
+    apply(event, twin, context, config, true);
+  }
+
+  private void apply(
+      TakEvent event,
+      EntityTwin twin,
+      TwinUpdateContext context,
+      CotConfigDTO config,
+      boolean removal) {
+    if (event == null || twin == null) {
+      return;
+    }
+
+    event.setType(resolveCotType(twin, config));
+    event.setHow(valueOrDefault(config == null ? null : config.getHow(), DEFAULT_HOW));
+    event.setUid(prefixUid(event.getUid(), config == null ? null : config.getUidPrefix()));
+
+    if (!removal) {
+      long staleTimeoutMillis = config == null ? DEFAULT_STALE_TIMEOUT_MILLIS : config.getStaleTimeoutMillis();
+      if (staleTimeoutMillis < 1) {
+        staleTimeoutMillis = DEFAULT_STALE_TIMEOUT_MILLIS;
+      }
+      Instant eventTime = resolveEventTime(event, context);
+      if (eventTime != null) {
+        event.setStale(eventTime.plusMillis(staleTimeoutMillis).toString());
+      }
+      applyPointDefaults(event.getPoint(), twin, config);
+    }
+
+    TakDetail detail = event.getDetail();
+    if (detail != null) {
+      TakPrecisionLocation precisionLocation = detail.getPrecisionLocation();
+      if (precisionLocation == null) {
+        precisionLocation = new TakPrecisionLocation();
+        detail.setPrecisionLocation(precisionLocation);
+      }
+      precisionLocation.setAltsrc(
+          valueOrDefault(config == null ? null : config.getAltitudeSource(), DEFAULT_ALTITUDE_SOURCE));
+    }
+  }
+
+  private String resolveCotType(EntityTwin twin, CotConfigDTO config) {
+    String affiliation = resolveAffiliationCode(twin, config);
+    VehicleClass vehicleClass = resolveVehicleClass(twin);
+    String classification =
+        switch (vehicleClass) {
+          case UAV -> "A-M-F-U";
+          case USV -> "S-X-M";
+          case UGV -> "G-E-V";
+          case UUV -> "U-X-M";
+          case GCS -> "G-U-C";
+          case UNKNOWN -> "X";
+        };
+    return "a-" + affiliation + '-' + classification;
+  }
+
+  private VehicleClass resolveVehicleClass(EntityTwin twin) {
+    if (twin instanceof DroneTwin droneTwin && droneTwin.getVehicleClass() != null) {
+      return droneTwin.getVehicleClass();
+    }
+    if (TwinType.GROUND_CONTROL.equals(twin.getTwinType())) {
+      return VehicleClass.GCS;
+    }
+    return VehicleClass.UNKNOWN;
+  }
+
+  private String resolveAffiliationCode(EntityTwin twin, CotConfigDTO config) {
+    CotAffiliation affiliation = config == null ? CotAffiliation.FRIENDLY : config.getAffiliation();
+    if (affiliation == null) {
+      affiliation = CotAffiliation.SOURCE;
+    }
+
+    return switch (affiliation) {
+      case FRIENDLY -> "f";
+      case HOSTILE -> "h";
+      case NEUTRAL -> "n";
+      case UNKNOWN -> "u";
+      case SOURCE -> resolveSourceAffiliation(twin);
+    };
+  }
+
+  private String resolveSourceAffiliation(EntityTwin twin) {
+    if (!(twin instanceof DroneTwin droneTwin)) {
+      return "u";
+    }
+
+    Map<String, Object> description = droneTwin.getDescription();
+    if (description == null || description.isEmpty()) {
+      return "u";
+    }
+
+    Object value = firstValue(description, "standard_identity", "standardIdentity", "affiliation");
+    if (value == null) {
+      return "u";
+    }
+
+    String normalised = String.valueOf(value).trim().toUpperCase(Locale.ROOT);
+    if (normalised.startsWith("STANDARDIDENTITYENUM_")) {
+      normalised = normalised.substring("STANDARDIDENTITYENUM_".length());
+    }
+
+    return switch (normalised) {
+      case "FRIEND", "FRIENDLY" -> "f";
+      case "ASSUMED_FRIEND" -> "a";
+      case "NEUTRAL" -> "n";
+      case "SUSPECT" -> "s";
+      case "HOSTILE", "ENEMY" -> "h";
+      case "PENDING" -> "p";
+      default -> "u";
+    };
+  }
+
+  private Object firstValue(Map<String, Object> values, String... keys) {
+    for (String key : keys) {
+      Object value = values.get(key);
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private void applyPointDefaults(TakPoint point, EntityTwin twin, CotConfigDTO config) {
+    if (point == null) {
+      return;
+    }
+
+    FixInfo fixInfo = twin.getFixInfo();
+    if (fixInfo == null
+        || fixInfo.getHorizontalAccuracyMeters() == null
+        || fixInfo.getHorizontalAccuracyMeters() <= 0.0d) {
+      point.setCe(resolveError(config == null ? null : config.getDefaultCircularErrorMeters(), DEFAULT_CE_METERS));
+    }
+    if (fixInfo == null
+        || fixInfo.getVerticalAccuracyMeters() == null
+        || fixInfo.getVerticalAccuracyMeters() <= 0.0d) {
+      point.setLe(resolveError(config == null ? null : config.getDefaultLinearErrorMeters(), DEFAULT_LE_METERS));
+    }
+  }
+
+  private double resolveError(Double configuredValue, double defaultValue) {
+    return configuredValue != null && Double.isFinite(configuredValue) && configuredValue >= 0.0d
+        ? configuredValue
+        : defaultValue;
+  }
+
+  private Instant resolveEventTime(TakEvent event, TwinUpdateContext context) {
+    if (event.getTime() != null && !event.getTime().isBlank()) {
+      try {
+        return Instant.parse(event.getTime());
+      } catch (RuntimeException ignored) {
+      }
+    }
+    return context == null ? null : context.getEventTime();
+  }
+
+  private String prefixUid(String uid, String prefix) {
+    if (prefix == null || prefix.isBlank()) {
+      return uid;
+    }
+    return prefix + (uid == null ? "" : uid);
+  }
+
+  private String valueOrDefault(String value, String defaultValue) {
+    return value == null || value.isBlank() ? defaultValue : value;
+  }
+}

--- a/src/main/java/io/mapsmessaging/state/drone/tak/TakTwinContext.java
+++ b/src/main/java/io/mapsmessaging/state/drone/tak/TakTwinContext.java
@@ -19,6 +19,7 @@
 
 package io.mapsmessaging.state.drone.tak;
 
+import io.mapsmessaging.state.config.CotConfigDTO;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,9 +28,11 @@ import lombok.Setter;
 public class TakTwinContext {
   private long lastUpdate;
   private TakSocketConnection socketConnection;
+  private CotConfigDTO cotConfig;
 
   public TakTwinContext(){
     lastUpdate = 0;
     socketConnection = null;
+    cotConfig = null;
   }
 }

--- a/src/main/java/io/mapsmessaging/state/drone/tak/TakTwinObserver.java
+++ b/src/main/java/io/mapsmessaging/state/drone/tak/TakTwinObserver.java
@@ -25,6 +25,7 @@ import io.mapsmessaging.dto.rest.config.protocol.impl.TakProtocolDTO;
 import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.security.ssl.SslHelper;
+import io.mapsmessaging.state.config.CotConfigDTO;
 import io.mapsmessaging.state.config.TwinManagerConfig;
 import io.mapsmessaging.state.config.TwinManagerConfigDTO;
 import io.mapsmessaging.state.drone.core.EntityTwin;
@@ -41,6 +42,7 @@ import io.mapsmessaging.utilities.configuration.ConfigurationManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,6 +67,9 @@ public class TakTwinObserver implements TwinObserver {
   private final TakXmlSerialiser takXmlSerialiser;
   private final TakSocketConnection globalSocketConnection;
   private final EventPublisher eventPublisher;
+  private final CotConfigResolver cotConfigResolver;
+  private final CotEventPolicy cotEventPolicy;
+  private final boolean namespaceFilteringEnabled;
 
   public TakTwinObserver(TwinManager twinManager) {
     this.twinManager = Objects.requireNonNull(twinManager, "twinManager cannot be null");
@@ -72,9 +77,13 @@ public class TakTwinObserver implements TwinObserver {
     this.lastStatsPublishTimes = new ConcurrentHashMap<>();
     this.takEventMapper = new TakEventMapper();
     this.takXmlSerialiser = new TakXmlSerialiser();
+    this.cotEventPolicy = new CotEventPolicy();
 
     TwinManagerConfigDTO config =
         ConfigurationManager.getInstance().getConfiguration(TwinManagerConfig.class);
+    List<CotConfigDTO> cotConfigs = config == null ? List.of() : config.getCot();
+    this.cotConfigResolver = new CotConfigResolver(cotConfigs);
+    this.namespaceFilteringEnabled = !cotConfigs.isEmpty();
 
     if (config != null && config.getTak() != null) {
       this.takHost = config.getTak().getHostname();
@@ -248,10 +257,16 @@ public class TakTwinObserver implements TwinObserver {
       return;
     }
 
+    CotConfigDTO cotConfig = resolveCotConfig(context, twinContext);
+    if (namespaceFilteringEnabled && cotConfig == null) {
+      return;
+    }
+
     TakEvent takEvent = takEventMapper.map(twin, context);
     if (takEvent == null) {
       return;
     }
+    cotEventPolicy.apply(takEvent, twin, context, cotConfig);
 
     String xml = takXmlSerialiser.toXml(takEvent);
     xml = appendStatsIfDue(twin, xml);
@@ -282,12 +297,42 @@ public class TakTwinObserver implements TwinObserver {
       return;
     }
 
+    CotConfigDTO cotConfig = resolveCotConfig(context, twinContext);
+    if (namespaceFilteringEnabled && cotConfig == null) {
+      return;
+    }
+
     TakEvent takEvent = takEventMapper.mapRemoval(twin, context);
     if (takEvent == null) {
       return;
     }
+    cotEventPolicy.applyRemoval(takEvent, twin, context, cotConfig);
 
     twinContext.getSocketConnection().accept(takXmlSerialiser.toXml(takEvent));
+  }
+
+  private CotConfigDTO resolveCotConfig(TwinUpdateContext context, TakTwinContext twinContext) {
+    if (context != null && context.getSourceNamespace() != null && !context.getSourceNamespace().isBlank()) {
+      CotConfigDTO match = cotConfigResolver.resolve(context.getSourceNamespace());
+      if (match != null) {
+        twinContext.setCotConfig(match);
+      }
+      return match;
+    }
+
+    if (twinContext.getCotConfig() != null) {
+      return twinContext.getCotConfig();
+    }
+
+    if (context != null && context.getUpdateSource() != null && !context.getUpdateSource().isBlank()) {
+      CotConfigDTO match = cotConfigResolver.resolve(context.getUpdateSource());
+      if (match != null) {
+        twinContext.setCotConfig(match);
+        return match;
+      }
+    }
+
+    return null;
   }
 
   private String appendStatsIfDue(EntityTwin twin, String xml) {

--- a/src/test/java/io/mapsmessaging/state/config/CotConfigDtoIntegrationTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/CotConfigDtoIntegrationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause.
+ */
+package io.mapsmessaging.state.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CotConfigDtoIntegrationTest {
+
+  @Test
+  void cotMappingsRoundTripThroughAdapterConfiguration() {
+    TwinManagerConfigDTO config = new TwinManagerConfigDTO();
+    CotConfigDTO mapping = new CotConfigDTO();
+    mapping.setNamespacePath("4817/catl/maps/#");
+    mapping.setAffiliation(CotAffiliation.FRIENDLY);
+
+    config.setCot(List.of(mapping));
+
+    assertTrue(config.getAdapterConfig().containsKey("cot"));
+    assertEquals(List.of(mapping), config.getCot());
+
+    config.setCot(List.of());
+    assertFalse(config.getAdapterConfig().containsKey("cot"));
+    assertTrue(config.getCot().isEmpty());
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/config/CotConfigDtoIntegrationTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/CotConfigDtoIntegrationTest.java
@@ -6,8 +6,10 @@ package io.mapsmessaging.state.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.mapsmessaging.configuration.ConfigurationProperties;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -28,5 +30,14 @@ class CotConfigDtoIntegrationTest {
     config.setCot(List.of());
     assertFalse(config.getAdapterConfig().containsKey("cot"));
     assertTrue(config.getCot().isEmpty());
+  }
+
+  @Test
+  void rejectsNonStandardAffiliationNames() {
+    ConfigurationProperties mapping = new ConfigurationProperties();
+    mapping.put("namespacePath", "4817/catl/maps/#");
+    mapping.put("affiliation", "ENEMY");
+
+    assertThrows(IllegalArgumentException.class, () -> CotConfigSupport.parse(mapping));
   }
 }

--- a/src/test/java/io/mapsmessaging/state/config/VehicleClassTest.java
+++ b/src/test/java/io/mapsmessaging/state/config/VehicleClassTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause.
+ */
+package io.mapsmessaging.state.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class VehicleClassTest {
+
+  @Test
+  void usesStanagSymbolSetNames() {
+    assertEquals("SymbolSetEnum_AIR", VehicleClass.UAV.getSymbolSet());
+    assertEquals("SymbolSetEnum_SEA_SURFACE", VehicleClass.USV.getSymbolSet());
+    assertEquals("SymbolSetEnum_LAND_UNIT", VehicleClass.UGV.getSymbolSet());
+    assertEquals("SymbolSetEnum_SEA_SUBSURFACE", VehicleClass.UUV.getSymbolSet());
+    assertEquals("SymbolSetEnum_CONTROL_MEASURE", VehicleClass.GCS.getSymbolSet());
+    assertEquals("SymbolSetEnum_UNKNOWN", VehicleClass.UNKNOWN.getSymbolSet());
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/drone/TwinRetentionPolicyTest.java
+++ b/src/test/java/io/mapsmessaging/state/drone/TwinRetentionPolicyTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause.
+ */
+package io.mapsmessaging.state.drone;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.mapsmessaging.state.drone.core.EntityTwin;
+import io.mapsmessaging.state.drone.core.TwinLifecycleStatus;
+import io.mapsmessaging.state.drone.core.TwinManager;
+import io.mapsmessaging.state.drone.core.TwinObserver;
+import io.mapsmessaging.state.drone.core.TwinRetentionPolicy;
+import io.mapsmessaging.state.drone.core.TwinUpdateContext;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class TwinRetentionPolicyTest {
+
+  private static final Instant REGISTERED_AT = Instant.parse("2026-09-12T10:00:00Z");
+
+  @Test
+  void defaultTwinIsPurgedAfterRetentionTimeout() {
+    TwinManager manager = manager();
+    manager.registerTwin(new DroneTwin("default"), context(REGISTERED_AT));
+
+    int removed = manager.purgeExpiredTwins(REGISTERED_AT.plusSeconds(121));
+
+    assertEquals(1, removed);
+    assertTrue(manager.getTwin("default").isEmpty());
+  }
+
+  @Test
+  void persistentTwinSurvivesRetentionPurgeButStillBecomesStale() {
+    TwinManager manager = manager();
+    DroneTwin persistent = new DroneTwin("persistent");
+    persistent.setRetentionPolicy(TwinRetentionPolicy.PERSISTENT);
+    manager.registerTwin(persistent, context(REGISTERED_AT));
+
+    manager.scanTwinStates(REGISTERED_AT.plusSeconds(20));
+    int removed = manager.purgeExpiredTwins(REGISTERED_AT.plusSeconds(121));
+
+    EntityTwin retained = manager.getTwin("persistent").orElseThrow();
+    assertEquals(0, removed);
+    assertEquals(TwinLifecycleStatus.STALE, retained.getLifecycleStatus());
+    assertFalse(retained.getLinkState().getConnected());
+  }
+
+  @Test
+  void persistentTwinCanStillBeRemovedExplicitlyAndNotifiesObservers() {
+    TwinManager manager = manager();
+    AtomicInteger removals = new AtomicInteger();
+    manager.addObserver(new TwinObserver() {
+      @Override
+      public void onTwinRemoved(EntityTwin removed, TwinUpdateContext context) {
+        removals.incrementAndGet();
+      }
+    });
+    DroneTwin persistent = new DroneTwin("persistent");
+    persistent.setRetentionPolicy(TwinRetentionPolicy.PERSISTENT);
+    manager.registerTwin(persistent, context(REGISTERED_AT));
+
+    assertTrue(manager.removeTwin("persistent", new TwinUpdateContext()).isPresent());
+    assertEquals(1, removals.get());
+    assertTrue(manager.getTwin("persistent").isEmpty());
+  }
+
+  private TwinManager manager() {
+    return new TwinManager(true, 10_000L, 5_000L, 120_000L, null);
+  }
+
+  private TwinUpdateContext context(Instant receivedAt) {
+    TwinUpdateContext context = new TwinUpdateContext();
+    context.setReceivedTime(receivedAt);
+    return context;
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/drone/tak/CotConfigResolverTest.java
+++ b/src/test/java/io/mapsmessaging/state/drone/tak/CotConfigResolverTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause.
+ */
+package io.mapsmessaging.state.drone.tak;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.mapsmessaging.state.config.CotAffiliation;
+import io.mapsmessaging.state.config.CotConfigDTO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CotConfigResolverTest {
+
+  @Test
+  void mostSpecificNamespaceWins() {
+    CotConfigDTO root = config("4817/#", CotAffiliation.FRIENDLY);
+    CotConfigDTO specific = config("4817/catl/external/+/+/+", CotAffiliation.HOSTILE);
+    CotConfigResolver resolver = new CotConfigResolver(List.of(root, specific));
+
+    assertSame(specific, resolver.resolve("4817/catl/external/json/node/MessageTypeEnum_NODE_STATUS"));
+    assertSame(root, resolver.resolve("4817/catl/maps/json/node/MessageTypeEnum_NODE_STATUS"));
+  }
+
+  @Test
+  void mqttStyleWildcardsAreSupported() {
+    assertTrue(CotConfigResolver.matches("4817/catl/+/+/+/+", "4817/catl/maps/json/node/MessageTypeEnum_NODE_STATUS"));
+    assertTrue(CotConfigResolver.matches("/4817/catl/#", "4817/catl/maps/json/node/MessageTypeEnum_NODE_STATUS"));
+  }
+
+  @Test
+  void unmatchedNamespaceIsNotMapped() {
+    CotConfigResolver resolver = new CotConfigResolver(List.of(config("4817/#", CotAffiliation.FRIENDLY)));
+
+    assertNull(resolver.resolve("mavlink/1/status"));
+    assertNull(resolver.resolve(null));
+  }
+
+  private CotConfigDTO config(String namespacePath, CotAffiliation affiliation) {
+    CotConfigDTO config = new CotConfigDTO();
+    config.setNamespacePath(namespacePath);
+    config.setAffiliation(affiliation);
+    return config;
+  }
+}

--- a/src/test/java/io/mapsmessaging/state/drone/tak/CotEventPolicyTest.java
+++ b/src/test/java/io/mapsmessaging/state/drone/tak/CotEventPolicyTest.java
@@ -52,6 +52,19 @@ class CotEventPolicyTest {
   }
 
   @Test
+  void nonStandardSourceAffiliationFallsBackToUnknown() {
+    DroneTwin twin = twin(VehicleClass.USV);
+    twin.getDescription().put("standard_identity", "ENEMY");
+    TakEvent event = mapper.map(twin, new TwinUpdateContext());
+    CotConfigDTO config = new CotConfigDTO();
+    config.setAffiliation(CotAffiliation.SOURCE);
+
+    policy.apply(event, twin, null, config);
+
+    assertEquals("a-u-S-X-M", event.getType());
+  }
+
+  @Test
   void appliesCotOnlyDefaultsFromNamespaceConfiguration() {
     DroneTwin twin = twin(VehicleClass.UAV);
     TakEvent event = mapper.map(twin, new TwinUpdateContext());

--- a/src/test/java/io/mapsmessaging/state/drone/tak/CotEventPolicyTest.java
+++ b/src/test/java/io/mapsmessaging/state/drone/tak/CotEventPolicyTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause.
+ */
+package io.mapsmessaging.state.drone.tak;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.mapsmessaging.state.config.CotAffiliation;
+import io.mapsmessaging.state.config.CotConfigDTO;
+import io.mapsmessaging.state.config.VehicleClass;
+import io.mapsmessaging.state.drone.core.TwinUpdateContext;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import io.mapsmessaging.state.drone.model.GeoPosition;
+import io.mapsmessaging.state.drone.tak.model.TakEvent;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CotEventPolicyTest {
+
+  private final TakEventMapper mapper = new TakEventMapper();
+  private final CotEventPolicy policy = new CotEventPolicy();
+
+  @ParameterizedTest
+  @MethodSource("vehicleTypes")
+  void mapsVehicleClassWithoutAssumingSeaSurface(VehicleClass vehicleClass, String expectedType) {
+    DroneTwin twin = twin(vehicleClass);
+    TakEvent event = mapper.map(twin, new TwinUpdateContext());
+    CotConfigDTO config = new CotConfigDTO();
+    config.setAffiliation(CotAffiliation.FRIENDLY);
+
+    policy.apply(event, twin, null, config);
+
+    assertEquals(expectedType, event.getType());
+  }
+
+  @Test
+  void sourceAffiliationUsesStanagIdentity() {
+    DroneTwin twin = twin(VehicleClass.USV);
+    twin.getDescription().put("standard_identity", "StandardIdentityEnum_NEUTRAL");
+    TakEvent event = mapper.map(twin, new TwinUpdateContext());
+    CotConfigDTO config = new CotConfigDTO();
+    config.setAffiliation(CotAffiliation.SOURCE);
+
+    policy.apply(event, twin, null, config);
+
+    assertEquals("a-n-S-X-M", event.getType());
+  }
+
+  @Test
+  void appliesCotOnlyDefaultsFromNamespaceConfiguration() {
+    DroneTwin twin = twin(VehicleClass.UAV);
+    TakEvent event = mapper.map(twin, new TwinUpdateContext());
+    CotConfigDTO config = new CotConfigDTO();
+    config.setAffiliation(CotAffiliation.HOSTILE);
+    config.setHow("m-g");
+    config.setStaleTimeoutMillis(45_000L);
+    config.setUidPrefix("stanag-");
+    config.setDefaultCircularErrorMeters(25.0d);
+    config.setDefaultLinearErrorMeters(30.0d);
+    config.setAltitudeSource("BARO");
+
+    policy.apply(event, twin, null, config);
+
+    assertEquals("a-h-A-M-F-U", event.getType());
+    assertEquals("m-g", event.getHow());
+    assertEquals("stanag-drone-1", event.getUid());
+    assertEquals("2026-09-12T10:00:45Z", event.getStale());
+    assertEquals(25.0d, event.getPoint().getCe());
+    assertEquals(30.0d, event.getPoint().getLe());
+    assertEquals("BARO", event.getDetail().getPrecisionLocation().getAltsrc());
+  }
+
+  @Test
+  void removalKeepsImmediateStaleTime() {
+    DroneTwin twin = twin(VehicleClass.UUV);
+    TakEvent event = mapper.mapRemoval(twin, new TwinUpdateContext());
+    CotConfigDTO config = new CotConfigDTO();
+    config.setAffiliation(CotAffiliation.NEUTRAL);
+    config.setStaleTimeoutMillis(120_000L);
+
+    policy.applyRemoval(event, twin, null, config);
+
+    assertEquals("a-n-U-X-M", event.getType());
+    assertEquals("2026-09-12T10:00:01Z", event.getStale());
+  }
+
+  private DroneTwin twin(VehicleClass vehicleClass) {
+    DroneTwin twin = new DroneTwin("drone-1");
+    twin.setVehicleClass(vehicleClass);
+    twin.setGeoPosition(new GeoPosition(-33.0d, 151.0d, 0.0d, null));
+    twin.setLastSeenAt(Instant.parse("2026-09-12T10:00:00Z"));
+    return twin;
+  }
+
+  private static Stream<Arguments> vehicleTypes() {
+    return Stream.of(
+        Arguments.of(VehicleClass.UAV, "a-f-A-M-F-U"),
+        Arguments.of(VehicleClass.USV, "a-f-S-X-M"),
+        Arguments.of(VehicleClass.UGV, "a-f-G-E-V"),
+        Arguments.of(VehicleClass.UUV, "a-f-U-X-M"),
+        Arguments.of(VehicleClass.GCS, "a-f-G-U-C"),
+        Arguments.of(VehicleClass.UNKNOWN, "a-f-X"));
+  }
+}


### PR DESCRIPTION
## Summary

Add namespace-aware CoT mapping and the generic CONTACT/retention support required by external contact adapters such as MILCO.

Refs: MSG-247

## Scope

- typed CoT mapping configuration under the existing state-adapter configuration
- standard affiliation values only: `SOURCE`, `FRIENDLY`, `HOSTILE`, `NEUTRAL`, `UNKNOWN`
- MQTT-style namespace matching with most-specific match selection
- source namespace provenance on `TwinUpdateContext`
- CoT policy resolution for affiliation, `how`, stale interval, UID prefix, CE/LE and altitude source
- corrected STANAG vehicle symbol sets including `SEA_SUBSURFACE` and `CONTROL_MEASURE`
- generic `TwinType.CONTACT` required by external contact adapters
- generic `TwinRetentionPolicy { DEFAULT, PERSISTENT }`
- `TwinManager.purgeExpiredTwins` skips only explicitly persistent Twins; lifecycle ageing and manual removal remain unchanged
- compatibility constructor retained for `TwinUpdateContext`
- tests for namespace resolution, affiliation, CoT defaults, vehicle classes, symbol sets, non-standard affiliation rejection and persistent retention

## MILCO relationship

`Maps-Messaging/milco-state-adapter` PR #1 builds against this branch. MILCO-specific parsing and attributes remain outside the server. No second server branch is required.

## Validation status

Focused unit coverage is present on the branch. Maven is not installed in the current execution environment, so the full server Maven suite has not been run here. This PR remains draft pending the normal CI/build run.