### PR TITLE
feat(twin): add per-twin retention policy

### DIFF
--- a/src/main/java/io/mapsmessaging/state/drone/core/EntityTwin.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/EntityTwin.java
@@ -147,6 +147,12 @@ public abstract class EntityTwin {
   private TwinLifecycleStatus lifecycleStatus = TwinLifecycleStatus.ACTIVE;
 
   @Schema(
+      description = "Retention policy controlling scheduled removal after the global retention timeout.",
+      defaultValue = "DEFAULT",
+      nullable = false)
+  private TwinRetentionPolicy retentionPolicy = TwinRetentionPolicy.DEFAULT;
+
+  @Schema(
       description = "Relationship edges owned by this twin.",
       nullable = false
   )

--- a/src/main/java/io/mapsmessaging/state/drone/core/TwinManager.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/TwinManager.java
@@ -293,6 +293,9 @@ public class TwinManager {
     List<String> expiredIds = new ArrayList<>();
 
     for (EntityTwin twin : twins.values()) {
+      if (twin.getRetentionPolicy() == TwinRetentionPolicy.PERSISTENT) {
+        continue;
+      }
       long ageMillis = ageMillis(effectiveNow, twin.getLastSeenAt());
       if (ageMillis >= retentionTimeoutMillis) {
         expiredIds.add(twin.getTwinId());

--- a/src/main/java/io/mapsmessaging/state/drone/core/TwinRetentionPolicy.java
+++ b/src/main/java/io/mapsmessaging/state/drone/core/TwinRetentionPolicy.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.mapsmessaging.state.drone.core;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Retention policy controlling whether a Twin is removed by the global retention timeout.")
+public enum TwinRetentionPolicy {
+  DEFAULT,
+  PERSISTENT
+}

--- a/src/test/java/io/mapsmessaging/state/drone/TwinRetentionPolicyTest.java
+++ b/src/test/java/io/mapsmessaging/state/drone/TwinRetentionPolicyTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ * Licensed under the Apache License, Version 2.0 with the Commons Clause.
+ */
+package io.mapsmessaging.state.drone;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.mapsmessaging.state.drone.core.EntityTwin;
+import io.mapsmessaging.state.drone.core.TwinLifecycleStatus;
+import io.mapsmessaging.state.drone.core.TwinManager;
+import io.mapsmessaging.state.drone.core.TwinObserver;
+import io.mapsmessaging.state.drone.core.TwinRetentionPolicy;
+import io.mapsmessaging.state.drone.core.TwinUpdateContext;
+import io.mapsmessaging.state.drone.drone.DroneTwin;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class TwinRetentionPolicyTest {
+
+  private static final Instant REGISTERED_AT = Instant.parse("2026-09-12T10:00:00Z");
+
+  @Test
+  void defaultTwinIsPurgedAfterRetentionTimeout() {
+    TwinManager manager = manager();
+    manager.registerTwin(new DroneTwin("default"), context(REGISTERED_AT));
+
+    int removed = manager.purgeExpiredTwins(REGISTERED_AT.plusSeconds(121));
+
+    assertEquals(1, removed);
+    assertTrue(manager.getTwin("default").isEmpty());
+  }
+
+  @Test
+  void persistentTwinSurvivesRetentionPurgeButStillBecomesStale() {
+    TwinManager manager = manager();
+    DroneTwin persistent = new DroneTwin("persistent");
+    persistent.setRetentionPolicy(TwinRetentionPolicy.PERSISTENT);
+    manager.registerTwin(persistent, context(REGISTERED_AT));
+
+    manager.scanTwinStates(REGISTERED_AT.plusSeconds(20));
+    int removed = manager.purgeExpiredTwins(REGISTERED_AT.plusSeconds(121));
+
+    EntityTwin retained = manager.getTwin("persistent").orElseThrow();
+    assertEquals(0, removed);
+    assertEquals(TwinLifecycleStatus.STALE, retained.getLifecycleStatus());
+    assertFalse(retained.getLinkState().getConnected());
+  }
+
+  @Test
+  void persistentTwinCanStillBeRemovedExplicitlyAndNotifiesObservers() {
+    TwinManager manager = manager();
+    AtomicInteger removals = new AtomicInteger();
+    manager.addObserver(new TwinObserver() {
+      @Override
+      public void onTwinRemoved(EntityTwin removed, TwinUpdateContext context) {
+        removals.incrementAndGet();
+      }
+    });
+    DroneTwin persistent = new DroneTwin("persistent");
+    persistent.setRetentionPolicy(TwinRetentionPolicy.PERSISTENT);
+    manager.registerTwin(persistent, context(REGISTERED_AT));
+
+    assertTrue(manager.removeTwin("persistent", new TwinUpdateContext()).isPresent());
+    assertEquals(1, removals.get());
+    assertTrue(manager.getTwin("persistent").isEmpty());
+  }
+
+  private TwinManager manager() {
+    return new TwinManager(true, 10_000L, 5_000L, 120_000L, null);
+  }
+
+  private TwinUpdateContext context(Instant receivedAt) {
+    TwinUpdateContext context = new TwinUpdateContext();
+    context.setReceivedTime(receivedAt);
+    return context;
+  }
+}


### PR DESCRIPTION
Superseded by PR #2210. The generic `TwinRetentionPolicy` implementation and tests have been folded into `MSG-247-cot-classification` so MILCO requires one server branch to build and test.

No separate retention branch is required.